### PR TITLE
Allow piping to cli commands

### DIFF
--- a/inc/Composer/Command.php
+++ b/inc/Composer/Command.php
@@ -177,14 +177,17 @@ EOT
 			}
 		}
 
-		passthru( sprintf(
+		$has_stdin = ! posix_isatty( STDIN );
+		$command = sprintf(
 			'cd %s; VOLUME=%s COMPOSE_PROJECT_NAME=%s docker-compose exec %s -u nobody php wp %s',
 			'vendor/humanmade/local-server/docker',
 			getcwd(),
 			basename( getcwd() ),
-			! posix_isatty( STDOUT ) ? '-T' : '', // forward wp-cli's isPiped detection
+			$has_stdin || ! posix_isatty( STDOUT ) ? '-T' : '', // forward wp-cli's isPiped detection
 			implode( ' ', $options )
-		), $return_val );
+		);
+
+		passthru( $command, $return_val );
 
 		return $return_val;
 	}


### PR DESCRIPTION
Currently you can't say, pipe a file to `db import -`, as the TTY is not set. This detects when there is a STDIN and correctly enables the TTY on the connection to the docker container.