### PR TITLE
Add loopback http support

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,6 +17,8 @@ x-php: &php
   links:
     - "db:db-read-replica"
     - "s3:s3-${COMPOSE_PROJECT_NAME:-default}.s3.localhost"
+  external_links:
+    - "proxy:${COMPOSE_PROJECT_NAME}.altis.dev"
   volumes:
     - "${VOLUME}:/usr/src/app:delegated"
   environment:


### PR DESCRIPTION
Currently you can't make internal requests to the site url, as `*.altis.dev` resolves to 127.0.0.1 which is the IP of the container form internal requests. Instead we want to link the hostname to the traefik container.