### PR TITLE
Forward the terminal size when running cli commands

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -189,13 +189,16 @@ EOT
 				$option = $arg . '=' . escapeshellarg( substr( $option, strlen( $arg ) + 1 ) );
 			}
 		}
-
+		$columns = exec( 'tput cols' );
+		$lines = exec( 'tput lines' );
 		$has_stdin = ! posix_isatty( STDIN );
 		$command = sprintf(
-			'cd %s; VOLUME=%s COMPOSE_PROJECT_NAME=%s docker-compose exec %s -u nobody php wp %s',
+			'cd %s; VOLUME=%s COMPOSE_PROJECT_NAME=%s docker-compose exec -e COLUMNS=%d -e LINES=%d %s -u nobody php wp %s',
 			'vendor/altis/local-server/docker',
 			getcwd(),
 			$this->get_project_subdomain(),
+			$columns,
+			$lines,
 			$has_stdin || ! posix_isatty( STDOUT ) ? '-T' : '', // forward wp-cli's isPiped detection
 			implode( ' ', $options )
 		);


### PR DESCRIPTION
Currently the output from cli commands is matching the default in the docker container shell, but we should instead forward the values from the current terminal window.