### PR TITLE
Docs: BE → AE

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,7 +22,7 @@ All containers should have a status of "Up". If they do not, you can inspect the
 
 ## Services keep stopping
 
-By default docker machine sets a default memory limit of 2gb for all of your containers. Because of this if your system becomes too busy or you're running multiple instances of local server it is reccommended to increase this limit to at least 4gb.
+By default docker machine sets a default memory limit of 2gb for all of your containers. Because of this if your system becomes too busy or you're running multiple instances of local server it is recommended to increase this limit to at least 4gb.
 
 In the docker GUI go to the "Preferences" pane, then the "Advanced" tab and move the memory slider up.
 

--- a/docs/wp-cli.md
+++ b/docs/wp-cli.md
@@ -6,7 +6,7 @@ The Local Server allows you to run [WP CLI](https://wp-cli.org/) commands via th
 composer local-server cli -- post list
 ```
 
-To install a a new language file and activate it:
+To install a new language file and activate it:
 
 ```sh
 composer local-server cli -- language core install fr_FR


### PR DESCRIPTION
Actually just two typos I caught on the way. 🙂