### PR TITLE
WIP: Output username and password when starting

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -115,11 +115,14 @@ EOT
 
 			] ), $output ) === 0;
 			$output->writeln( 'Installed database.' );
+			$output->writeln( 'Username: admin' );
+			$output->writeln( 'Password: admin' );
 		}
 
 		$site_url = 'https://' . $this->get_project_subdomain() . '.altis.dev/';
 		$output->writeln( 'Startup completed.' );
 		$output->writeln( 'To access your site visit: ' . $site_url );
+
 	}
 
 	protected function stop( InputInterface $input, OutputInterface $output ) {


### PR DESCRIPTION
when installing WP for the first time, print out the username and password, closes #48

<img width="523" alt="Screenshot 2019-10-03 at 14 55 18" src="https://user-images.githubusercontent.com/58855/66133448-94076300-e5ee-11e9-867b-e7ee4a9f4fd4.png">
