### PR TITLE
Add the bucket prefix to the S3 URL

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -153,7 +153,7 @@ services:
       - "traefik.port=8000"
       - "traefik.protocol=http"
       - "traefik.docker.network=proxy"
-      - "traefik.frontend.rule=HostRegexp:s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
+      - "traefik.frontend.rule=HostRegexp:s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev;AddPrefix:/s3-${COMPOSE_PROJECT_NAME:-default}"
   tachyon:
     image: humanmade/tachyon:1.1.0
     ports:


### PR DESCRIPTION
After uploading images S3 Uploads does a HEAD request to the bucket URL - the defined bucket URL is actually the main endpoint right now so this adds the actual bucket path within traefik.