### PR TITLE
Fix Traefik to v1.7

### DIFF
--- a/docker/proxy.yml
+++ b/docker/proxy.yml
@@ -3,7 +3,7 @@ services:
   proxy:
     networks:
       - proxy
-    image: traefik
+    image: traefik:1.7
     volumes:
       - "$PWD/conf/traefik.toml:/etc/traefik/traefik.toml"
       - "$PWD/ssl.cert:/etc/traefik/ssl.cert"


### PR DESCRIPTION
v2 of Traefik changed the config format, so this pins Traefik to v1.7 until that can be updated