### PR TITLE
Ensure S3 bucket and uploads dir exist on start

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -143,6 +143,15 @@ EOT
 				'--quiet',
 			],
 		] ), $output );
+		$cli->run( new ArrayInput( [
+			'subcommand' => 'cli',
+			'options' => [
+				's3-uploads',
+				'rm',
+				's3://s3-' . $this->get_project_subdomain() . '/uploads/composer.json',
+				'--quiet',
+			],
+		] ), $output );
 
 		$site_url = 'https://' . $this->get_project_subdomain() . '.altis.dev/';
 		$output->writeln( '<info>Startup completed.</>' );

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -106,6 +106,7 @@ EOT
 			'options' => [
 				'core',
 				'is-installed',
+				'--quiet',
 			],
 		] ), $output ) === 0;
 
@@ -121,6 +122,7 @@ EOT
 					'--admin_email=no-reply@altis.dev',
 					'--skip-email',
 					'--skip-config',
+					'--quiet',
 				],
 
 			] ), $output ) === 0;
@@ -128,6 +130,19 @@ EOT
 			$output->writeln( '<info>WP Username:</>	<comment>admin</>' );
 			$output->writeln( '<info>WP Password:</>	<comment>admin</>' );
 		}
+
+		// Ensure uploads directory is present by copying a known file.
+		// Prevents errors when running WordPress unit tests.
+		$cli->run( new ArrayInput( [
+			'subcommand' => 'cli',
+			'options' => [
+				's3-uploads',
+				'cp',
+				'composer.json',
+				's3://s3-' . $this->get_project_subdomain() . '/uploads/composer.json',
+				'--quiet',
+			],
+		] ), $output );
 
 		$site_url = 'https://' . $this->get_project_subdomain() . '.altis.dev/';
 		$output->writeln( '<info>Startup completed.</>' );


### PR DESCRIPTION
WordPress and in particular WP unit tests don't factor in a missing uploads directory. Because we're using fakes3 the bucket and directories aren't created until an image is first uploaded. This will avoid errors being thrown.