### PR TITLE
Make the es mem_limit configurable

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -121,7 +121,7 @@ services:
       memlock:
         soft: -1
         hard: -1
-    mem_limit: 1g
+    mem_limit: ${ES_MEM_LIMIT:-1g}
     volumes:
       - es-data:/usr/share/elasticsearch/data
     ports:


### PR DESCRIPTION
This allows for setting an environment variable to change the elasticsearch memory limit.

The reason for this is that it's required to increase this limit to 2g to get the local server running successfully on a Travis CI VM. We have 7.5Gb RAM available on the host so I don't think there are any other issues here.