### PR TITLE
Don't output whole log on logs command

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -220,7 +220,7 @@ EOT
 
 	protected function logs( InputInterface $input, OutputInterface $output ) {
 		$log = $input->getArgument( 'options' )[0];
-		$compose = new Process( 'docker-compose logs -f ' . $log, 'vendor/altis/local-server/docker', [
+		$compose = new Process( 'docker-compose logs --tail=100 -f ' . $log, 'vendor/altis/local-server/docker', [
 			'VOLUME' => getcwd(),
 			'COMPOSE_PROJECT_NAME' => $this->get_project_subdomain(),
 		] );


### PR DESCRIPTION
The logs is intended to tail the log, so we should only fetch 100 last entries.