### PR TITLE
Improve performance of exec in cli

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -232,17 +232,21 @@ EOT
 				$option = $arg . '=' . escapeshellarg( substr( $option, strlen( $arg ) + 1 ) );
 			}
 		}
+
+		$container_id = exec( sprintf( 'docker ps --filter name=%s_php_1 -q', $this->get_project_subdomain() ) );
+		if ( ! $container_id ) {
+			return $output->writeln( '<error>PHP container not found to run command.</>' );
+		}
+
 		$columns = exec( 'tput cols' );
 		$lines = exec( 'tput lines' );
 		$has_stdin = ! posix_isatty( STDIN );
 		$command = sprintf(
-			'cd %s; VOLUME=%s COMPOSE_PROJECT_NAME=%s docker-compose exec -e COLUMNS=%d -e LINES=%d %s -u nobody php %s %s',
-			'vendor/altis/local-server/docker',
-			getcwd(),
-			$this->get_project_subdomain(),
+			'docker exec -e COLUMNS=%d -e LINES=%d -u nobody %s %s %s %s',
 			$columns,
 			$lines,
 			( $has_stdin || ! posix_isatty( STDOUT ) ) && $program === 'wp' ? '-T' : '', // forward wp-cli's isPiped detection
+			$container_id,
 			$program ?? '',
 			implode( ' ', $options )
 		);


### PR DESCRIPTION
Currently the time to run exec is signififcant (3.5+ seconds on my computer). This is mostly because docker-compose has a very slow startup time (see https://github.com/docker/compose/issues/4748 and #76). Instead of running `exec` via compose, we look up the container ID and run it from there. This reduces all exec invocations to around 800ms from 3.5+ seconds. This impacts WP CLI usages, the install (first wp install) time, and also the runninf of phpunit via dev-tools. phpunit is something you want to be perticularily fast for developer feedback on fast running tests.

Fixes #76.