### PR TITLE
Docker exec tty uses lower case t

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -252,7 +252,7 @@ EOT
 			'docker exec -e COLUMNS=%d -e LINES=%d -u nobody %s %s %s %s',
 			$columns,
 			$lines,
-			( $has_stdin || ! posix_isatty( STDOUT ) ) && $program === 'wp' ? '-T' : '', // forward wp-cli's isPiped detection
+			( $has_stdin || ! posix_isatty( STDOUT ) ) && $program === 'wp' ? '-t' : '', // forward wp-cli's isPiped detection
 			$container_id,
 			$program ?? '',
 			implode( ' ', $options )


### PR DESCRIPTION
Seeing the following error:

```
unknown shorthand flag: 'T' in -T
See 'docker exec --help'.
```