### PR TITLE
Restart cavalcade on failure

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -116,6 +116,7 @@ services:
     entrypoint:
       - /usr/local/bin/cavalcade
     user: "nobody:nobody"
+    restart: on-failure
   elasticsearch:
     image: humanmade/altis-local-server-elasticsearch:1.0.0-rc1
     ulimits:


### PR DESCRIPTION
Because the server is ready before WP is installed the runner starts and finds the table doesn't exist then promptly exits and stops the container. Not ideal!