### PR TITLE
Add shared socket volume for nginx/php socket communication

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,6 +22,7 @@ x-php: &php
   volumes:
     - "${VOLUME}:/usr/src/app:delegated"
     - "${PWD}/php.ini:/usr/local/etc/php/conf.d/altis.ini"
+    - socket:/var/run/php-fpm
   environment:
     HOST_PATH: ${VOLUME}
     DB_HOST: db
@@ -95,6 +96,7 @@ services:
       - php
     volumes:
       - "${VOLUME}:/usr/src/app:delegated"
+      - socket:/var/run/php-fpm
     ports:
       - "8080"
     labels:
@@ -236,3 +238,4 @@ volumes:
   es-data:
   tmp:
   s3:
+  socket:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,7 @@ x-php: &php
       condition: service_started
     mailhog:
       condition: service_started
-  image: humanmade/altis-local-server-php:3.0.0
+  image: humanmade/altis-local-server-php:3.1.0
   links:
     - "db:db-read-replica"
     - "s3:s3.localhost"
@@ -84,11 +84,11 @@ services:
       - '6379'
   php:
     <<: *php
-    image: ${PHP_IMAGE:-humanmade/altis-local-server-php:3.0.0}
+    image: ${PHP_IMAGE:-humanmade/altis-local-server-php:3.1.0}
     ports:
       - '9000'
   nginx:
-    image: humanmade/altis-local-server-nginx:1.0.0
+    image: humanmade/altis-local-server-nginx:3.1.0
     networks:
       - proxy
       - default

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -100,7 +100,7 @@ EOT
 		];
 
 		if ( $input->getOption( 'xdebug' ) ) {
-			$env['PHP_IMAGE'] = 'humanmade/altis-local-server-php:3.0.0-dev';
+			$env['PHP_IMAGE'] = 'humanmade/altis-local-server-php:3.1.0';
 			$env['PHP_XDEBUG_ENABLED'] = true;
 		}
 

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -100,7 +100,7 @@ EOT
 		];
 
 		if ( $input->getOption( 'xdebug' ) ) {
-			$env['PHP_IMAGE'] = 'humanmade/altis-local-server-php:3.1.0';
+			$env['PHP_IMAGE'] = 'humanmade/altis-local-server-php:3.1.0-dev';
 			$env['PHP_XDEBUG_ENABLED'] = true;
 		}
 


### PR DESCRIPTION
https://github.com/humanmade/docker-wordpress-php/pull/28 and https://github.com/humanmade/docker-wordpress-nginx/pull/13 update nginx/php communication to use a Unix Socket instead of TCP. This adds a shared volume for them to communicate over. Once those two PRs are merged and new tags released, we can update the tags referenced in `docker-compose.yml`.