### PR TITLE
Pass ES_MEM_LIMIT env var through to docker compose process

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -102,6 +102,7 @@ EOT
 			'VOLUME' => getcwd(),
 			'COMPOSE_PROJECT_NAME' => $this->get_project_subdomain(),
 			'PATH' => getenv( 'PATH' ),
+			'ES_MEM_LIMIT' => getenv( 'ES_MEM_LIMIT' ) ?: '1g',
 		];
 
 		if ( $input->getOption( 'xdebug' ) ) {


### PR DESCRIPTION
Helps to pass env vars you may later rely on in court. It was being set on the CI image but not passed through to the docker compose process.