### PR TITLE
Don't send empty cookie on every request

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -79,8 +79,6 @@ function bootstrap() {
 	// Set XDebug cookie if environment variable is set.
 	if ( getenv( 'PHP_XDEBUG_ENABLED' ) ) {
 		setcookie( 'XDEBUG_SESSION', $_SERVER['HTTP_HOST'], strtotime( '+1 year' ), '/', $_SERVER['HTTP_HOST'] );
-	} else {
-		setcookie( 'XDEBUG_SESSION', $_SERVER['HTTP_HOST'], time() - 1, '/', $_SERVER['HTTP_HOST'] );
 	}
 
 	add_filter( 'qm/output/file_path_map', __NAMESPACE__ . '\\set_file_path_map', 1 );


### PR DESCRIPTION
When not using `PHP_XDEBUG_ENABLED`, we currently send a blank cookie on _every_ request. This is wasteful, but also means you won't get Batcache locally because of cookies being set, and can snag other problems too.

I don't really see why we even need to set this at all. In this context.