### PR TITLE
Update the Pinpoint container to 1.2.2

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -203,7 +203,7 @@ services:
       - "traefik.frontend.rule=Host:cognito-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
   pinpoint:
     <<: *analytics
-    image: humanmade/local-pinpoint:1.1.0
+    image: humanmade/local-pinpoint:1.2.2
     labels:
       - "traefik.port=3000"
       - "traefik.protocol=http"


### PR DESCRIPTION
This brings in support for creating and updating endpoints via the putEvents method as per production. This is needed to support the new method for updating endpoints brought in with the changes in https://github.com/humanmade/analytics/pull/38