### PR TITLE
Network PHP container to allow access to service hostnames

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,10 +19,15 @@ x-php: &php
     - "s3:s3.localhost"
   external_links:
     - "proxy:${COMPOSE_PROJECT_NAME:-default}.altis.dev"
+    - "proxy:pinpoint-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
+    - "proxy:cognito-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
   volumes:
     - "${VOLUME}:/usr/src/app:delegated"
     - "${PWD}/php.ini:/usr/local/etc/php/conf.d/altis.ini"
     - socket:/var/run/php-fpm
+  networks:
+    - proxy
+    - default
   environment:
     HOST_PATH: ${VOLUME}
     DB_HOST: db
@@ -85,8 +90,6 @@ services:
   php:
     <<: *php
     image: ${PHP_IMAGE:-humanmade/altis-local-server-php:3.1.0}
-    ports:
-      - '9000'
   nginx:
     image: humanmade/altis-local-server-nginx:3.1.0
     networks:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,6 +21,8 @@ x-php: &php
     - "proxy:${COMPOSE_PROJECT_NAME:-default}.altis.dev"
     - "proxy:pinpoint-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
     - "proxy:cognito-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
+    - "proxy:elasticsearch-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
+    - "proxy:s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
   volumes:
     - "${VOLUME}:/usr/src/app:delegated"
     - "${PWD}/php.ini:/usr/local/etc/php/conf.d/altis.ini"


### PR DESCRIPTION
Now PHP uses sockets instead of port 9000 for the Nginx -> PHP connection, we can put PHP on the main proxy network. This means it's then easy to link in the hostnames of our services to the traefik HTTP server.

This means we can make requests from PHP to https://project.altis.dev/ as well as https://pinpoint-project.altis.dev/ etc.