### PR TITLE
Use Minio for S3 storage

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ x-php: &php
   image: humanmade/altis-local-server-php:3.1.0
   links:
     - "db:db-read-replica"
-    - "s3:s3.localhost"
+    - "minio:s3.localhost"
   external_links:
     - "proxy:${COMPOSE_PROJECT_NAME:-default}.altis.dev"
     - "proxy:pinpoint-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
@@ -47,7 +47,7 @@ x-php: &php
     ELASTICSEARCH_HOST: elasticsearch
     ELASTICSEARCH_PORT: 9200
     AWS_XRAY_DAEMON_HOST: xray
-    S3_UPLOADS_ENDPOINT: http://s3.localhost:8000/
+    S3_UPLOADS_ENDPOINT: http://s3.localhost:9000/
     S3_UPLOADS_BUCKET: s3-${COMPOSE_PROJECT_NAME:-default}
     S3_UPLOADS_BUCKET_URL: https://s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev
     S3_UPLOADS_KEY: not-needed
@@ -152,20 +152,35 @@ services:
       - "traefik.frontend.rule=HostRegexp:elasticsearch-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
     environment:
       - http.max_content_length=10mb
-  s3:
-    image: fingershock/fakes3:0.2.4
+  minio:
+    image: minio/minio
     volumes:
-      - "s3:/fakes3_data:rw"
+      - "minio:/data:rw"
     ports:
-      - "8000"
+      - "9000"
     networks:
       - proxy
       - default
+    environment:
+      MINIO_ACCESS_KEY: not-needed
+      MINIO_SECRET_KEY: not-needed
+    command: server /data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
     labels:
-      - "traefik.port=8000"
+      - "traefik.port=9000"
       - "traefik.protocol=http"
       - "traefik.docker.network=proxy"
       - "traefik.frontend.rule=HostRegexp:s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev;AddPrefix:/s3-${COMPOSE_PROJECT_NAME:-default}"
+  mc:
+    image: minio/mc
+    volumes:
+      - "minio.json:.mc/config.json"
+    links:
+      - "minio"
   tachyon:
     image: humanmade/tachyon:2.2.1
     ports:
@@ -180,9 +195,9 @@ services:
     environment:
       AWS_REGION: not-needed
       AWS_S3_BUCKET: s3-${COMPOSE_PROJECT_NAME:-default}
-      AWS_S3_ENDPOINT: http://s3.localhost:8000/
+      AWS_S3_ENDPOINT: http://s3.localhost:9000/
     links:
-      - "s3:s3.localhost"
+      - "minio:s3.localhost"
   mailhog:
     image: mailhog/mailhog:latest
     ports:
@@ -244,5 +259,5 @@ volumes:
   db-data:
   es-data:
   tmp:
-  s3:
+  minio:
   socket:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,8 @@ x-php: &php
   image: humanmade/altis-local-server-php:3.1.0
   links:
     - "db:db-read-replica"
-    - "minio:s3.localhost"
+    - "s3:s3.localhost"
+    - "s3:s3-${COMPOSE_PROJECT_NAME:-default}.s3.localhost"
   external_links:
     - "proxy:${COMPOSE_PROJECT_NAME:-default}.altis.dev"
     - "proxy:pinpoint-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
@@ -50,9 +51,9 @@ x-php: &php
     S3_UPLOADS_ENDPOINT: http://s3.localhost:9000/
     S3_UPLOADS_BUCKET: s3-${COMPOSE_PROJECT_NAME:-default}
     S3_UPLOADS_BUCKET_URL: https://s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev
-    S3_UPLOADS_KEY: not-needed
-    S3_UPLOADS_SECRET: not-needed
-    S3_UPLOADS_REGION: not-needed
+    S3_UPLOADS_KEY: admin
+    S3_UPLOADS_SECRET: password
+    S3_UPLOADS_REGION: us-east-1
     TACHYON_URL: https://${COMPOSE_PROJECT_NAME:-default}.altis.dev/tachyon
     PHP_SENDMAIL_PATH: /usr/sbin/sendmail -t -i -S mailhog:1025
     ALTIS_ANALYTICS_PINPOINT_ENDPOINT: https://pinpoint-${COMPOSE_PROJECT_NAME:-default}.altis.dev
@@ -67,6 +68,14 @@ x-analytics: &analytics
     - proxy
     - default
   restart: on-failure
+
+x-mc: &mc
+  image: minio/mc:RELEASE.2020-03-14T01-23-37Z
+  volumes:
+    - "${PWD}/minio.json:/root/.mc/config.json"
+    - "${VOLUME}/content/uploads:/content/uploads:delegated"
+  links:
+    - "s3"
 
 services:
   db:
@@ -152,19 +161,20 @@ services:
       - "traefik.frontend.rule=HostRegexp:elasticsearch-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
     environment:
       - http.max_content_length=10mb
-  minio:
-    image: minio/minio
+  s3:
+    image: minio/minio:RELEASE.2020-03-19T21-49-00Z
     volumes:
-      - "minio:/data:rw"
+      - "s3:/data:rw"
     ports:
       - "9000"
     networks:
       - proxy
       - default
     environment:
-      MINIO_DOMAIN: altis.dev
-      MINIO_ACCESS_KEY: not-needed
-      MINIO_SECRET_KEY: not-needed
+      MINIO_DOMAIN: s3.localhost,altis.dev,s3
+      MINIO_REGION_NAME: us-east-1
+      MINIO_ACCESS_KEY: admin
+      MINIO_SECRET_KEY: password
     command: server /data
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
@@ -175,13 +185,27 @@ services:
       - "traefik.port=9000"
       - "traefik.protocol=http"
       - "traefik.docker.network=proxy"
-      - "traefik.frontend.rule=HostRegexp:s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev;AddPrefix:/s3-${COMPOSE_PROJECT_NAME:-default}"
-  mc:
-    image: minio/mc
-    volumes:
-      - "minio.json:.mc/config.json"
-    links:
-      - "minio"
+      - "traefik.frontend.rule=HostRegexp:s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
+  s3-make-bucket:
+    <<: *mc
+    depends_on:
+      - s3
+    command: ["mb", "local/s3-${COMPOSE_PROJECT_NAME:-default}"]
+  s3-set-policy:
+    <<: *mc
+    depends_on:
+      - s3-make-bucket
+    command: ["policy", "set", "public", "local/s3-${COMPOSE_PROJECT_NAME:-default}"]
+  s3-sync-up:
+    <<: *mc
+    depends_on:
+      - s3-make-bucket
+    command: ["mirror", "--watch", "--overwrite", "local/s3-${COMPOSE_PROJECT_NAME:-default}", "/content"]
+  s3-sync-down:
+    <<: *mc
+    depends_on:
+      - s3-make-bucket
+    command: ["mirror", "/content", "local/s3-${COMPOSE_PROJECT_NAME:-default}"]
   tachyon:
     image: humanmade/tachyon:2.2.1
     ports:
@@ -194,11 +218,12 @@ services:
       - "traefik.docker.network=proxy"
       - "traefik.frontend.rule=HostRegexp:${COMPOSE_PROJECT_NAME:-default}.altis.dev,{subdomain:[a-z.-_]+}.${COMPOSE_PROJECT_NAME:-default}.altis.dev;PathPrefix:/tachyon;ReplacePathRegex:^/tachyon/(.*) /uploads/$$1"
     environment:
-      AWS_REGION: not-needed
+      AWS_REGION: us-east-1
       AWS_S3_BUCKET: s3-${COMPOSE_PROJECT_NAME:-default}
       AWS_S3_ENDPOINT: http://s3.localhost:9000/
     links:
-      - "minio:s3.localhost"
+      - "s3:s3.localhost"
+      - "s3:s3-${COMPOSE_PROJECT_NAME:-default}.s3.localhost"
   mailhog:
     image: mailhog/mailhog:latest
     ports:
@@ -260,5 +285,5 @@ volumes:
   db-data:
   es-data:
   tmp:
-  minio:
+  s3:
   socket:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -205,7 +205,7 @@ services:
     <<: *mc
     depends_on:
       - s3-make-bucket
-    command: ["mirror", "/content", "local/s3-${COMPOSE_PROJECT_NAME:-default}"]
+    command: ["mirror", "/content", "--overwrite", "local/s3-${COMPOSE_PROJECT_NAME:-default}"]
   tachyon:
     image: humanmade/tachyon:2.2.1
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -69,14 +69,6 @@ x-analytics: &analytics
     - default
   restart: on-failure
 
-x-mc: &mc
-  image: minio/mc:RELEASE.2020-03-14T01-23-37Z
-  volumes:
-    - "${PWD}/minio.json:/root/.mc/config.json"
-    - "${VOLUME}/content/uploads:/content/uploads:delegated"
-  links:
-    - "s3"
-
 services:
   db:
     image: mysql:5.7
@@ -186,26 +178,20 @@ services:
       - "traefik.protocol=http"
       - "traefik.docker.network=proxy"
       - "traefik.frontend.rule=HostRegexp:s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
-  s3-make-bucket:
-    <<: *mc
+  s3-sync-to-host:
+    image: minio/mc:RELEASE.2020-03-14T01-23-37Z
     depends_on:
       - s3
-    command: ["mb", "local/s3-${COMPOSE_PROJECT_NAME:-default}"]
-  s3-set-policy:
-    <<: *mc
-    depends_on:
-      - s3-make-bucket
-    command: ["policy", "set", "public", "local/s3-${COMPOSE_PROJECT_NAME:-default}"]
-  s3-sync-up:
-    <<: *mc
-    depends_on:
-      - s3-make-bucket
-    command: ["mirror", "--watch", "--overwrite", "local/s3-${COMPOSE_PROJECT_NAME:-default}", "/content"]
-  s3-sync-down:
-    <<: *mc
-    depends_on:
-      - s3-make-bucket
-    command: ["mirror", "/content", "--overwrite", "local/s3-${COMPOSE_PROJECT_NAME:-default}"]
+    volumes:
+      - "${PWD}/minio.json:/root/.mc/config.json"
+      - "${VOLUME}/content/uploads:/content/uploads:delegated"
+    links:
+      - s3
+    entrypoint: >
+      /bin/sh -c "
+      mc mb -p local/s3-${COMPOSE_PROJECT_NAME:-default}
+      && mc policy set public local/s3-${COMPOSE_PROJECT_NAME:-default}
+      && mc mirror --watch local/s3-${COMPOSE_PROJECT_NAME:-default} /content"
   tachyon:
     image: humanmade/tachyon:2.2.1
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -162,6 +162,7 @@ services:
       - proxy
       - default
     environment:
+      MINIO_DOMAIN: altis.dev
       MINIO_ACCESS_KEY: not-needed
       MINIO_SECRET_KEY: not-needed
     command: server /data

--- a/docker/minio.json
+++ b/docker/minio.json
@@ -1,0 +1,12 @@
+{
+	"version": "9",
+	"hosts": {
+		"local": {
+			"url": "http://minio:9000",
+			"accessKey": "not-needed",
+			"secretKey": "not-needed",
+			"api": "S3v4",
+			"lookup": "auto"
+		}
+	}
+}

--- a/docker/minio.json
+++ b/docker/minio.json
@@ -2,9 +2,9 @@
 	"version": "9",
 	"hosts": {
 		"local": {
-			"url": "http://minio:9000",
-			"accessKey": "not-needed",
-			"secretKey": "not-needed",
+			"url": "http://s3:9000",
+			"accessKey": "admin",
+			"secretKey": "password",
 			"api": "S3v4",
 			"lookup": "auto"
 		}

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ The subdomain used for the project can be configured via the `modules.local-serv
 
 * `composer server start [--xdebug]` - Starts the containers.
   * If the `--xdebug` option is passed the PHP container will have XDebug enabled. To switch off XDebug run this command again without the `--xdebug` option.
-  * Any files in `content/upload` are synced to the S3 server on start up. Run this any time you need to synchronise files.
+  * Any files in `content/upload` are synced to the S3 server on start up.
 * `composer server stop` - Stops the containers.
 * `composer server restart` - Restart the containers.
 * `composer server destroy` - Stops and destroys all containers.
@@ -59,3 +59,4 @@ The subdomain used for the project can be configured via the `modules.local-serv
 * `composer server db` - Logs into MySQL on the DB container.
   * `composer server db info` - Print MySQL connection details.
   * `composer server db sequel` - Opens a connection to the database in [Sequel Pro](https://sequelpro.com).
+* `composer server sync` - Sync files from `content/uploads` to the s3 container.

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,6 @@ The subdomain used for the project can be configured via the `modules.local-serv
 
 * `composer server start [--xdebug]` - Starts the containers.
   * If the `--xdebug` option is passed the PHP container will have XDebug enabled. To switch off XDebug run this command again without the `--xdebug` option.
-  * Any files in `content/upload` are synced to the S3 server on start up.
 * `composer server stop` - Stops the containers.
 * `composer server restart` - Restart the containers.
 * `composer server destroy` - Stops and destroys all containers.
@@ -59,4 +58,4 @@ The subdomain used for the project can be configured via the `modules.local-serv
 * `composer server db` - Logs into MySQL on the DB container.
   * `composer server db info` - Print MySQL connection details.
   * `composer server db sequel` - Opens a connection to the database in [Sequel Pro](https://sequelpro.com).
-* `composer server sync` - Sync files from `content/uploads` to the s3 container.
+* `composer server import-uploads` - Syncs files from `content/uploads` to the s3 container.

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,9 @@ The subdomain used for the project can be configured via the `modules.local-serv
 
 ## Available Commands
 
-* `composer server start [--xdebug]` - Starts the containers. If the `--xdebug` option is passed the PHP container will have XDebug enabled. To switch off XDebug run this command again without the `--xdebug` option.
+* `composer server start [--xdebug]` - Starts the containers.
+  * If the `--xdebug` option is passed the PHP container will have XDebug enabled. To switch off XDebug run this command again without the `--xdebug` option.
+  * Any files in `content/upload` are synced to the S3 server on start up. Run this any time you need to synchronise files.
 * `composer server stop` - Stops the containers.
 * `composer server restart` - Restart the containers.
 * `composer server destroy` - Stops and destroys all containers.

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -176,28 +176,6 @@ EOT
 			$output->writeln( '<info>WP Password:</>	<comment>admin</>' );
 		}
 
-		// Ensure uploads directory is present by copying a known file.
-		// Prevents errors when running WordPress unit tests.
-		$cli->run( new ArrayInput( [
-			'subcommand' => 'cli',
-			'options' => [
-				's3-uploads',
-				'cp',
-				'composer.json',
-				's3://s3-' . $this->get_project_subdomain() . '/uploads/composer.json',
-				'--quiet',
-			],
-		] ), $output );
-		$cli->run( new ArrayInput( [
-			'subcommand' => 'cli',
-			'options' => [
-				's3-uploads',
-				'rm',
-				's3://s3-' . $this->get_project_subdomain() . '/uploads/composer.json',
-				'--quiet',
-			],
-		] ), $output );
-
 		$site_url = 'https://' . $this->get_project_subdomain() . '.altis.dev/';
 		$output->writeln( '<info>Startup completed.</>' );
 		$output->writeln( '<info>To access your site visit:</> <comment>' . $site_url . '</>' );

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -48,6 +48,8 @@ Database commands:
 	db info                       Prints out Database connection details
 View the logs
 	logs <service>                <service> can be php, nginx, db, s3, elasticsearch, xray
+Sync content/uploads directly to s3:
+	sync                          Copies files from `content/uploads` to s3
 EOT
 			)
 			->addOption( 'xdebug' );
@@ -89,6 +91,8 @@ EOT
 			return $this->logs( $input, $output );
 		} elseif ( $subcommand === 'shell' ) {
 			return $this->shell( $input, $output );
+		} elseif ( $subcommand === 'sync' ) {
+			return $this->sync( $input, $output );
 		} elseif ( $subcommand === null ) {
 			// Default to start command.
 			return $this->start( $input, $output );
@@ -437,6 +441,12 @@ EOT;
 				'PORT' => $ports_matches[2],
 			]
 		);
+	}
+
+	protected function sync() {
+		$command = sprintf( '%s docker-compose run s3-sync-down', $this->get_base_command_prefix() );
+		passthru( $command, $return_var );
+		return $return_var;
 	}
 
 	/**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -23,7 +23,6 @@ function bootstrap() {
 		add_filter( 's3_uploads_s3_client_params', function ( $params ) {
 			if ( defined( 'S3_UPLOADS_ENDPOINT' ) ) {
 				$params['endpoint'] = S3_UPLOADS_ENDPOINT;
-				$params['use_path_style_endpoint'] = true;
 			}
 			return $params;
 		}, 5, 1 );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -112,6 +112,10 @@ function tools_submenus() {
 			'label' => 'MailHog',
 			'url' => network_site_url( '/mailhog' ),
 		],
+		[
+			'label' => 'S3 Browser',
+			'url' => S3_UPLOADS_BUCKET_URL . '/minio',
+		],
 	];
 
 	foreach ( $links as $link ) {


### PR DESCRIPTION
This update switches from fakes3 to minio plus the minio client (mc). This
   allows us to properly support virtualhost style routing as per AWS where
   the subdomain selects the bucket.

   By using the `mc` docker image we can remove some not too robust code that
   was designed to ensure the bucket was created by uploading a file and then
   removing it.

   Additionally we can use `mc` to run a synchronisation service. Currently I
   have this running to sync from s3 to `content/uploads`. During startup eg.
   `composer serve` any existing files in `content/uploads` are synced to s3.
   Unfortunately getting this to work well in a bidirectional way is almost
   impossible. So we may want to think about our preferred direction to do
   synchronisation by default and perhaps even add a command to run the sync
   from the host to s3.

Fixes #140

Related to #142