### PR TITLE
Change exec function to run cli commands as www-data instead of nobody

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -278,7 +278,7 @@ EOT
 		$lines = exec( 'tput lines' );
 		$has_stdin = ! posix_isatty( STDIN );
 		$command = sprintf(
-			'docker exec -e COLUMNS=%d -e LINES=%d -u nobody %s %s %s %s',
+			'docker exec -e COLUMNS=%d -e LINES=%d -u www-data %s %s %s %s',
 			$columns,
 			$lines,
 			( $has_stdin || ! posix_isatty( STDOUT ) ) && $program === 'wp' ? '-t' : '', // forward wp-cli's isPiped detection


### PR DESCRIPTION
If a user goes to run a command that would modify the filesystem (such as manually installing a plugin), they will be denied access as `nobody` does not have sufficient permissions to write to /usr/src/app. Changing this to www-data will grant those permissions.