### PR TITLE
V2: Change exec function to run cli commands as www-data instead of nobody

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -193,7 +193,7 @@ EOT
 		$lines = exec( 'tput lines' );
 		$has_stdin = ! posix_isatty( STDIN );
 		$command = sprintf(
-			'cd %s; VOLUME=%s COMPOSE_PROJECT_NAME=%s docker-compose exec -e COLUMNS=%d -e LINES=%d %s -u nobody php wp %s',
+			'cd %s; VOLUME=%s COMPOSE_PROJECT_NAME=%s docker-compose exec -e COLUMNS=%d -e LINES=%d %s -u www-data php wp %s',
 			'vendor/altis/local-server/docker',
 			getcwd(),
 			$this->get_project_subdomain(),


### PR DESCRIPTION
If a user goes to run a command that would modify the filesystem (such as manually installing a plugin), they will be denied access as nobody does not have sufficient permissions to write to /usr/src/app. Changing this to www-data will grant those permissions.