### PR TITLE
Add support for Signed Urls in Tachyon

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -48,7 +48,7 @@ x-php: &php
     ELASTICSEARCH_HOST: elasticsearch
     ELASTICSEARCH_PORT: 9200
     AWS_XRAY_DAEMON_HOST: xray
-    S3_UPLOADS_ENDPOINT: http://s3.localhost:9000/
+    S3_UPLOADS_ENDPOINT: https://altis.dev/
     S3_UPLOADS_BUCKET: s3-${COMPOSE_PROJECT_NAME:-default}
     S3_UPLOADS_BUCKET_URL: https://s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev
     S3_UPLOADS_KEY: admin
@@ -206,10 +206,9 @@ services:
     environment:
       AWS_REGION: us-east-1
       AWS_S3_BUCKET: s3-${COMPOSE_PROJECT_NAME:-default}
-      AWS_S3_ENDPOINT: http://s3.localhost:9000/
-    links:
-      - "s3:s3.localhost"
-      - "s3:s3-${COMPOSE_PROJECT_NAME:-default}.s3.localhost"
+      AWS_S3_ENDPOINT: https://altis.dev/
+    external_links:
+      - "proxy:s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
   mailhog:
     image: mailhog/mailhog:latest
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -193,7 +193,7 @@ services:
       && mc policy set public local/s3-${COMPOSE_PROJECT_NAME:-default}
       && mc mirror --watch local/s3-${COMPOSE_PROJECT_NAME:-default} /content"
   tachyon:
-    image: humanmade/tachyon:2.2.1
+    image: humanmade/tachyon:2.3.0
     ports:
       - "8080"
     networks:

--- a/docker/minio.json
+++ b/docker/minio.json
@@ -6,7 +6,7 @@
 			"accessKey": "admin",
 			"secretKey": "password",
 			"api": "S3v4",
-			"lookup": "auto"
+			"lookup": "virtual"
 		}
 	}
 }


### PR DESCRIPTION
Currently we have  mix between using path-type and subdomain-style S3 bucket urls in Local Server. Because Tachyon, and the WordPress application use different URLs patterns, it means the Signed URLs generated between them are not compatible (the url path is part of the signature, so the path has to be the same in both).

We've sinse added support for loop-back requests to the S3 container on the proxy network, so we can now use the "s3-$project.altis.dev" hostname from the Tahcyon container, matching the hostname we use from the WordPress applicatio container. It also means we don't need to change the behaviour of the S3 SDK to special-case local development.