### PR TITLE
Only set the X-Ray daemon address if it isn't already defined

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -40,7 +40,9 @@ function bootstrap() {
 	define( 'ELASTICSEARCH_HOST', getenv( 'ELASTICSEARCH_HOST' ) );
 	define( 'ELASTICSEARCH_PORT', getenv( 'ELASTICSEARCH_PORT' ) );
 
-	define( 'AWS_XRAY_DAEMON_IP_ADDRESS', gethostbyname( getenv( 'AWS_XRAY_DAEMON_HOST' ) ) );
+	if ( ! defined( 'AWS_XRAY_DAEMON_IP_ADDRESS' ) ) {
+		define( 'AWS_XRAY_DAEMON_IP_ADDRESS', gethostbyname( getenv( 'AWS_XRAY_DAEMON_HOST' ) ) );
+	}
 
 	global $redis_server;
 	$redis_server = [


### PR DESCRIPTION
This avoids a notice in some cases.