### PR TITLE
Fix tty / stdin detection

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -277,11 +277,12 @@ EOT
 		$columns = exec( 'tput cols' );
 		$lines = exec( 'tput lines' );
 		$has_stdin = ! posix_isatty( STDIN );
+		$has_stdout = ! posix_isatty( STDOUT );
 		$command = sprintf(
 			'docker exec -e COLUMNS=%d -e LINES=%d -u www-data %s %s %s %s',
 			$columns,
 			$lines,
-			( $has_stdin || ! posix_isatty( STDOUT ) ) && $program === 'wp' ? '-t' : '', // forward wp-cli's isPiped detection
+			( ! $has_stdin && ! $has_stdout ) && $program === 'wp' ? '-ti' : '', // forward wp-cli's isPiped detection
 			$container_id,
 			$program ?? '',
 			implode( ' ', $options )


### PR DESCRIPTION
At some point in the past, we broke detection of piped data. This meant things like `wp post list` didn't have formatting, as WP CLI didn't think there was a TTY.