### PR TITLE
Set the default admin password to 'password'

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,14 +18,17 @@ Navigate your shell to your project's directory. You should already have install
 
 To start the Local Server, run `composer server`. The first time you run this it will download all the necessary Docker images.
 
-Once the initial install and download has completed, you should see the output:
+Once the initial download and install has completed, you should see the output:
 
 ```sh
+Installed database.
+WP Username:	admin
+WP Password:	password
 Startup completed.
 To access your site visit: https://my-site.altis.dev/
 ```
 
-Visiting your site's URL should now work. Visit `/wp-admin/` and login with `admin` / `admin` to get started!
+Visiting your site's URL should now work. Visit `/wp-admin/` and login with the username `admin` and password `password` to get started!
 
 > [If the server does not start for any reason take a look at the troubleshooting guide](./troubleshooting.md)
 

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -161,7 +161,7 @@ EOT
 					'multisite-install',
 					'--title=Altis',
 					'--admin_user=admin',
-					'--admin_password=admin',
+					'--admin_password=password',
 					'--admin_email=no-reply@altis.dev',
 					'--skip-email',
 					'--skip-config',
@@ -177,7 +177,7 @@ EOT
 
 			$output->writeln( '<info>Installed database.</>' );
 			$output->writeln( '<info>WP Username:</>	<comment>admin</>' );
-			$output->writeln( '<info>WP Password:</>	<comment>admin</>' );
+			$output->writeln( '<info>WP Password:</>	<comment>password</>' );
 		}
 
 		$site_url = 'https://' . $this->get_project_subdomain() . '.altis.dev/';


### PR DESCRIPTION
This to stay consistent with the local chassis environment. Fixes #161