### PR TITLE
Fix memory usage in ES

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -144,8 +144,6 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
-    environment:
-      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
     labels:
       - "traefik.port=9200"
       - "traefik.protocol=http"
@@ -153,6 +151,7 @@ services:
       - "traefik.frontend.rule=HostRegexp:elasticsearch-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
     environment:
       - http.max_content_length=10mb
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
   s3:
     image: minio/minio:RELEASE.2020-03-19T21-49-00Z
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -152,6 +152,10 @@ services:
     environment:
       - http.max_content_length=10mb
 
+      # Force ES into single-node mode (otherwise defaults to zen discovery as
+      # network.host is set in the default config)
+      - discovery.type=single-node
+
       # Reduce from default of 1GB of memory to 512MB
       - ES_JAVA_OPTS=-Xms512m -Xmx512m
   s3:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -151,6 +151,8 @@ services:
       - "traefik.frontend.rule=HostRegexp:elasticsearch-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
     environment:
       - http.max_content_length=10mb
+
+      # Reduce from default of 1GB of memory to 512MB
       - ES_JAVA_OPTS=-Xms512m -Xmx512m
   s3:
     image: minio/minio:RELEASE.2020-03-19T21-49-00Z


### PR DESCRIPTION
Fixes #115.

#44 added a new environment option, which overrode the existing one where we set the memory limit for Java. This meant that Java was trying to use more memory than the container was actually allocated, getting it killed by the OOM killer.

Additionally, because the [config sets network.host](https://github.com/blacktop/docker-elasticsearch-alpine/blob/765493a6597d20b583e8b82536d0ec5fcc357e32/6.3/config/elastic/elasticsearch.yml#L1), ES [switches into production mode](https://www.elastic.co/guide/en/elasticsearch/reference/master/bootstrap-checks.html#dev-vs-prod-mode). Notably, this turns the bootstrap checks from warnings into exceptions, which means that ES doesn't launch due to the low `vm.max_map_count` value. To switch it back into development mode, we need to change the discovery type back to single node (which is another env var we can set here).

All up, this should fix the ES memory problems and other related startup problems; it should also now not be necessary to increase Docker's memory limit.