### PR TITLE
Stop containers restarting if docker daemon rebooted

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -67,7 +67,7 @@ x-analytics: &analytics
   networks:
     - proxy
     - default
-  restart: on-failure
+  restart: unless-stopped
 
 services:
   db:
@@ -124,7 +124,7 @@ services:
     entrypoint:
       - /usr/local/bin/cavalcade
     user: "nobody:nobody"
-    restart: on-failure
+    restart: unless-stopped
   elasticsearch:
     image: humanmade/altis-local-server-elasticsearch:3.0.0
     ulimits:


### PR DESCRIPTION
The `on-failure` restart policy meant that if you shut down or rebooted your laptop without first halting the local server then the cavalcade and analytics services would immediately try to start back up again without the rest of the required services to function.

This is primarily an issue for Cavalcade which runs every second, fails and restarts every second.

Changing to `unless-stopped` will ensure these services stay up for the durection of the local server instance or until the docker daemon is restarted such as after a shutdown / reboot.

Fixes #164