### PR TITLE
Increase healtcheck timeout for ElasticSearch

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -143,7 +143,7 @@ services:
       test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
       interval: 5s
       timeout: 5s
-      retries: 10
+      retries: 25
     labels:
       - "traefik.port=9200"
       - "traefik.protocol=http"


### PR DESCRIPTION
Per #150, ES can take upto (well, in my case) 110 seconds, so this change will increase the healthcheck time to 125 seconds.