### PR TITLE
Add ES package support

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -197,7 +197,7 @@ services:
       /bin/sh -c "
       mc mb -p local/s3-${COMPOSE_PROJECT_NAME:-default}
       && mc policy set public local/s3-${COMPOSE_PROJECT_NAME:-default}
-      && mc mirror --watch local/s3-${COMPOSE_PROJECT_NAME:-default} /content"
+      && mc mirror --watch --overwrite local/s3-${COMPOSE_PROJECT_NAME:-default} /content"
   tachyon:
     image: humanmade/tachyon:2.3.0
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,7 +28,6 @@ x-php: &php
     - "${VOLUME}:/usr/src/app:delegated"
     - "${PWD}/php.ini:/usr/local/etc/php/conf.d/altis.ini"
     - socket:/var/run/php-fpm
-    - es-packages:/usr/src/es-packages:delegated
   networks:
     - proxy
     - default
@@ -135,7 +134,7 @@ services:
     mem_limit: ${ES_MEM_LIMIT:-1g}
     volumes:
       - es-data:/usr/share/elasticsearch/data
-      - es-packages:/usr/share/elasticsearch/config/packages
+      - ${VOLUME}/content/uploads/es-packages:/usr/share/elasticsearch/config/packages
     ports:
       - "9200"
     networks:
@@ -277,7 +276,6 @@ networks:
 volumes:
   db-data:
   es-data:
-  es-packages:
   tmp:
   s3:
   socket:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,6 +28,7 @@ x-php: &php
     - "${VOLUME}:/usr/src/app:delegated"
     - "${PWD}/php.ini:/usr/local/etc/php/conf.d/altis.ini"
     - socket:/var/run/php-fpm
+    - es-packages:/usr/src/es-packages:delegated
   networks:
     - proxy
     - default
@@ -134,7 +135,7 @@ services:
     mem_limit: ${ES_MEM_LIMIT:-1g}
     volumes:
       - es-data:/usr/share/elasticsearch/data
-      - "${VOLUME}/content/uploads/search:/usr/share/elasticsearch/config/packages"
+      - es-packages:/usr/share/elasticsearch/config/packages
     ports:
       - "9200"
     networks:
@@ -276,6 +277,7 @@ networks:
 volumes:
   db-data:
   es-data:
+  es-packages:
   tmp:
   s3:
   socket:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -134,6 +134,7 @@ services:
     mem_limit: ${ES_MEM_LIMIT:-1g}
     volumes:
       - es-data:/usr/share/elasticsearch/data
+      - "${VOLUME}/content/uploads/search:/usr/share/elasticsearch/config/packages"
     ports:
       - "9200"
     networks:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -186,6 +186,7 @@ services:
       - "traefik.frontend.rule=HostRegexp:s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
   s3-sync-to-host:
     image: minio/mc:RELEASE.2020-03-14T01-23-37Z
+    restart: unless-stopped
     depends_on:
       - s3
     volumes:

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -90,6 +90,9 @@ function bootstrap() {
 	}
 
 	add_filter( 'qm/output/file_path_map', __NAMESPACE__ . '\\set_file_path_map', 1 );
+
+	// Filter ES package IDs for local.
+	add_filter( 'altis.search.package_id', __NAMESPACE__ . '\\set_search_package_id', 10, 2 );
 }
 
 /**
@@ -128,4 +131,16 @@ function tools_submenus() {
 	foreach ( $links as $link ) {
 		add_management_page( $link['label'], $link['label'], 'manage_options', $link['url'] );
 	}
+}
+
+/**
+ * Override the derived ES package file name for local server.
+ *
+ * @param string|null $id The package ID used for the file path in ES.
+ * @param string $file The package file path on S3.
+ * @return string
+ */
+function set_search_package_id( $id, string $file ) : string {
+	$id = sprintf( 'packages/%s', basename( $file ) );
+	return $id;
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -92,7 +92,8 @@ function bootstrap() {
 	add_filter( 'qm/output/file_path_map', __NAMESPACE__ . '\\set_file_path_map', 1 );
 
 	// Filter ES package IDs for local.
-	add_filter( 'altis.search.package_id', __NAMESPACE__ . '\\set_search_package_id', 10, 2 );
+	add_filter( 'altis.search.packages_dir', __NAMESPACE__ . '\\set_search_packages_dir' );
+	add_filter( 'altis.search.create_package_id', __NAMESPACE__ . '\\set_search_package_id', 10, 2 );
 }
 
 /**
@@ -134,6 +135,17 @@ function tools_submenus() {
 }
 
 /**
+ * Override Elasticsearch package storage location to es-packages volume.
+ *
+ * This directory is shared with the Elasticsearch container.
+ *
+ * @return string
+ */
+function set_search_packages_dir() : string {
+	return '/usr/src/es-packages';
+}
+
+/**
  * Override the derived ES package file name for local server.
  *
  * @param string|null $id The package ID used for the file path in ES.
@@ -141,6 +153,6 @@ function tools_submenus() {
  * @return string|null
  */
 function set_search_package_id( $id, string $file ) : ?string {
-	$id = sprintf( 'packages/%s', basename( $file ) );
+	$id = sprintf( 'es-packages/%s', basename( $file ) );
 	return $id;
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -26,7 +26,7 @@ function bootstrap() {
 		define( 'S3_UPLOADS_BUCKET_URL', getenv( 'S3_UPLOADS_BUCKET_URL' ) );
 
 		add_filter( 's3_uploads_s3_client_params', function ( $params ) {
-			if ( defined( 'S3_UPLOADS_ENDPOINT' ) ) {
+			if ( defined( 'S3_UPLOADS_ENDPOINT' ) && S3_UPLOADS_ENDPOINT ) {
 				$params['endpoint'] = S3_UPLOADS_ENDPOINT;
 			}
 			return $params;
@@ -138,9 +138,9 @@ function tools_submenus() {
  *
  * @param string|null $id The package ID used for the file path in ES.
  * @param string $file The package file path on S3.
- * @return string
+ * @return string|null
  */
-function set_search_package_id( $id, string $file ) : string {
+function set_search_package_id( $id, string $file ) : ?string {
 	$id = sprintf( 'packages/%s', basename( $file ) );
 	return $id;
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -93,7 +93,7 @@ function bootstrap() {
 
 	// Filter ES package IDs for local.
 	add_filter( 'altis.search.packages_dir', __NAMESPACE__ . '\\set_search_packages_dir' );
-	add_filter( 'altis.search.create_package_id', __NAMESPACE__ . '\\set_search_package_id', 10, 2 );
+	add_filter( 'altis.search.create_package_id', __NAMESPACE__ . '\\set_search_package_id', 10, 3 );
 }
 
 /**
@@ -142,17 +142,18 @@ function tools_submenus() {
  * @return string
  */
 function set_search_packages_dir() : string {
-	return '/usr/src/es-packages';
+	return sprintf( 's3://%s/uploads/es-packages', S3_UPLOADS_BUCKET );
 }
 
 /**
  * Override the derived ES package file name for local server.
  *
  * @param string|null $id The package ID used for the file path in ES.
+ * @param string $slug The package slug.
  * @param string $file The package file path on S3.
  * @return string|null
  */
-function set_search_package_id( $id, string $file ) : ?string {
-	$id = sprintf( 'es-packages/%s', basename( $file ) );
+function set_search_package_id( $id, string $slug, string $file ) : ?string {
+	$id = sprintf( 'packages/%s', basename( $file ) );
 	return $id;
 }


### PR DESCRIPTION
Related to user dictionary support https://github.com/humanmade/altis-enhanced-search/pull/76

This allows local server to interact with the package functionality in the search module.

I couldn't find a better solution unfortunately due to the limitations of not being to write any files to the PHP container, even if it's a volume. I had to write files to S3, then rely on the S3 sync to host service and mount that directory on to the Elasticsearch container.

The `docker-compose.yml` updates to the S3 sync and its restart policy should help keep this as robust as it can be in the current form.