### PR TITLE
Support XDebug on Linux

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -59,7 +59,9 @@ x-php: &php
     PHP_SENDMAIL_PATH: /usr/sbin/sendmail -t -i -S mailhog:1025
     ALTIS_ANALYTICS_PINPOINT_ENDPOINT: https://pinpoint-${COMPOSE_PROJECT_NAME:-default}.altis.dev
     ALTIS_ANALYTICS_COGNITO_ENDPOINT: https://cognito-${COMPOSE_PROJECT_NAME:-default}.altis.dev
+    # Setting required for minimal config in PHPStorm
     PHP_IDE_CONFIG: serverName=${COMPOSE_PROJECT_NAME:-default}.altis.dev
+    # Enables XDebug for all processes and allows setting remote_host externally for Linux support
     XDEBUG_CONFIG: idekey=${COMPOSE_PROJECT_NAME:-default}.altis.dev remote_host=${XDEBUG_REMOTE_HOST:-host.docker.internal}
 
 x-analytics: &analytics

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -60,7 +60,7 @@ x-php: &php
     ALTIS_ANALYTICS_PINPOINT_ENDPOINT: https://pinpoint-${COMPOSE_PROJECT_NAME:-default}.altis.dev
     ALTIS_ANALYTICS_COGNITO_ENDPOINT: https://cognito-${COMPOSE_PROJECT_NAME:-default}.altis.dev
     PHP_IDE_CONFIG: serverName=${COMPOSE_PROJECT_NAME:-default}.altis.dev
-    XDEBUG_CONFIG: idekey=${COMPOSE_PROJECT_NAME:-default}.altis.dev
+    XDEBUG_CONFIG: idekey=${COMPOSE_PROJECT_NAME:-default}.altis.dev remote_host=${XDEBUG_REMOTE_HOST:-host.docker.internal}
 
 x-analytics: &analytics
   ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,7 +26,8 @@ x-php: &php
     - "proxy:s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev"
   volumes:
     - "${VOLUME}:/usr/src/app:delegated"
-    - "${PWD}/php.ini:/usr/local/etc/php/conf.d/altis.ini"
+    # Use zzz as a prefix to ensure the php.ini overrides are loaded last
+    - "${PWD}/php.ini:/usr/local/etc/php/conf.d/zzz-altis.ini"
     - socket:/var/run/php-fpm
   networks:
     - proxy
@@ -58,8 +59,8 @@ x-php: &php
     PHP_SENDMAIL_PATH: /usr/sbin/sendmail -t -i -S mailhog:1025
     ALTIS_ANALYTICS_PINPOINT_ENDPOINT: https://pinpoint-${COMPOSE_PROJECT_NAME:-default}.altis.dev
     ALTIS_ANALYTICS_COGNITO_ENDPOINT: https://cognito-${COMPOSE_PROJECT_NAME:-default}.altis.dev
-    PHP_XDEBUG_ENABLED:
     PHP_IDE_CONFIG: serverName=${COMPOSE_PROJECT_NAME:-default}.altis.dev
+    XDEBUG_CONFIG: idekey=${COMPOSE_PROJECT_NAME:-default}.altis.dev
 
 x-analytics: &analytics
   ports:

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -2,3 +2,7 @@
 
 # Set sendmail to use mailhog.
 sendmail_path = ${PHP_SENDMAIL_PATH}
+
+# XDebug
+xdebug.default_enable = 1
+xdebug.remote_connect_back = 1

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -2,7 +2,3 @@
 
 # Set sendmail to use mailhog.
 sendmail_path = ${PHP_SENDMAIL_PATH}
-
-# XDebug
-xdebug.default_enable = 1
-xdebug.remote_connect_back = 1

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -2,3 +2,6 @@
 
 # Set sendmail to use mailhog.
 sendmail_path = ${PHP_SENDMAIL_PATH}
+
+# XDebug
+xdebug.default_enable = 1

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -173,8 +173,7 @@ EOT
 		$env = $this->get_env();
 		if ( $input->getOption( 'xdebug' ) ) {
 			$env['PHP_IMAGE'] = 'humanmade/altis-local-server-php:3.2.0-dev';
-			// phpcs:ignore PHPCompatibility.Constants.NewConstants.php_os_familyFound
-			if ( in_array( PHP_OS_FAMILY, [ 'BSD', 'Linux', 'Solaris', 'Unknown' ], true ) ) {
+			if ( in_array( php_uname( 's' ), [ 'BSD', 'Linux', 'Solaris', 'Unknown' ], true ) ) {
 				$env['XEBUG_REMOTE_HOST'] = '172.17.0.1';
 			}
 		}
@@ -479,8 +478,7 @@ EOT;
 				$output->write( $db_info );
 				break;
 			case 'sequel':
-				// phpcs:ignore PHPCompatibility.Constants.NewConstants.php_os_familyFound
-				if ( PHP_OS_FAMILY === 'Darwin' ) {
+				if ( php_uname( 's' ) === 'Darwin' ) {
 					$output->writeln( '<error>This command is only supported on MacOS, use composer server db info to see the database connection details.</error>' );
 					return 1;
 				}

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -174,7 +174,7 @@ EOT
 		if ( $input->getOption( 'xdebug' ) ) {
 			$env['PHP_IMAGE'] = 'humanmade/altis-local-server-php:3.2.0-dev';
 			if ( in_array( php_uname( 's' ), [ 'BSD', 'Linux', 'Solaris', 'Unknown' ], true ) ) {
-				$env['XEBUG_REMOTE_HOST'] = '172.17.0.1';
+				$env['XDEBUG_REMOTE_HOST'] = '172.17.0.1';
 			}
 		}
 

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -173,6 +173,9 @@ EOT
 		$env = $this->get_env();
 		if ( $input->getOption( 'xdebug' ) ) {
 			$env['PHP_IMAGE'] = 'humanmade/altis-local-server-php:3.2.0-dev';
+			if ( in_array( PHP_OS_FAMILY, [ 'BSD', 'Linux', 'Solaris', 'Unknown' ], true ) ) {
+				$env['XEBUG_REMOTE_HOST'] = '172.17.0.1';
+			}
 		}
 
 		$compose = new Process( 'docker-compose up -d', 'vendor/altis/local-server/docker', $env );
@@ -296,12 +299,7 @@ EOT
 	protected function restart( InputInterface $input, OutputInterface $output ) {
 		$output->writeln( '<info>Restarting...</>' );
 
-		$env = $this->get_env();
-		if ( $input->getOption( 'xdebug' ) ) {
-			$env['PHP_IMAGE'] = 'humanmade/altis-local-server-php:3.2.0-dev';
-		}
-
-		$proxy = new Process( 'docker-compose restart', 'vendor/altis/local-server/docker', $env );
+		$proxy = new Process( 'docker-compose restart', 'vendor/altis/local-server/docker', $this->get_env() );
 		$proxy->run();
 
 		$options = $input->getArgument( 'options' );
@@ -310,7 +308,7 @@ EOT
 		} else {
 			$service = '';
 		}
-		$compose = new Process( "docker-compose restart $service", 'vendor/altis/local-server/docker', $env );
+		$compose = new Process( "docker-compose restart $service", 'vendor/altis/local-server/docker', $this->get_env() );
 		$return_val = $compose->run( function ( $type, $buffer ) {
 			echo $buffer;
 		} );
@@ -480,7 +478,7 @@ EOT;
 				$output->write( $db_info );
 				break;
 			case 'sequel':
-				if ( strpos( php_uname(), 'Darwin' ) === false ) {
+				if ( PHP_OS_FAMILY === 'Darwin' ) {
 					$output->writeln( '<error>This command is only supported on MacOS, use composer server db info to see the database connection details.</error>' );
 					return 1;
 				}

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -173,6 +173,7 @@ EOT
 		$env = $this->get_env();
 		if ( $input->getOption( 'xdebug' ) ) {
 			$env['PHP_IMAGE'] = 'humanmade/altis-local-server-php:3.2.0-dev';
+			// phpcs:ignore PHPCompatibility.Constants.NewConstants.php_os_familyFound
 			if ( in_array( PHP_OS_FAMILY, [ 'BSD', 'Linux', 'Solaris', 'Unknown' ], true ) ) {
 				$env['XEBUG_REMOTE_HOST'] = '172.17.0.1';
 			}
@@ -478,6 +479,7 @@ EOT;
 				$output->write( $db_info );
 				break;
 			case 'sequel':
+				// phpcs:ignore PHPCompatibility.Constants.NewConstants.php_os_familyFound
 				if ( PHP_OS_FAMILY === 'Darwin' ) {
 					$output->writeln( '<error>This command is only supported on MacOS, use composer server db info to see the database connection details.</error>' );
 					return 1;

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -173,7 +173,6 @@ EOT
 		$env = $this->get_env();
 		if ( $input->getOption( 'xdebug' ) ) {
 			$env['PHP_IMAGE'] = 'humanmade/altis-local-server-php:3.2.0-dev';
-			$env['PHP_XDEBUG_ENABLED'] = true;
 		}
 
 		$compose = new Process( 'docker-compose up -d', 'vendor/altis/local-server/docker', $env );
@@ -297,7 +296,12 @@ EOT
 	protected function restart( InputInterface $input, OutputInterface $output ) {
 		$output->writeln( '<info>Restarting...</>' );
 
-		$proxy = new Process( 'docker-compose restart', 'vendor/altis/local-server/docker', $this->get_env() );
+		$env = $this->get_env();
+		if ( $input->getOption( 'xdebug' ) ) {
+			$env['PHP_IMAGE'] = 'humanmade/altis-local-server-php:3.2.0-dev';
+		}
+
+		$proxy = new Process( 'docker-compose restart', 'vendor/altis/local-server/docker', $env );
 		$proxy->run();
 
 		$options = $input->getArgument( 'options' );
@@ -306,7 +310,7 @@ EOT
 		} else {
 			$service = '';
 		}
-		$compose = new Process( "docker-compose restart $service", 'vendor/altis/local-server/docker', $this->get_env() );
+		$compose = new Process( "docker-compose restart $service", 'vendor/altis/local-server/docker', $env );
 		$return_val = $compose->run( function ( $type, $buffer ) {
 			echo $buffer;
 		} );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -82,11 +82,6 @@ function bootstrap() {
 		define( 'ALTIS_ANALYTICS_COGNITO_ENDPOINT', getenv( 'ALTIS_ANALYTICS_COGNITO_ENDPOINT' ) );
 	}
 
-	// Set XDebug cookie if environment variable is set.
-	if ( getenv( 'PHP_XDEBUG_ENABLED' ) ) {
-		setcookie( 'XDEBUG_SESSION', $_SERVER['HTTP_HOST'], strtotime( '+1 year' ), '/', $_SERVER['HTTP_HOST'] );
-	}
-
 	add_filter( 'qm/output/file_path_map', __NAMESPACE__ . '\\set_file_path_map', 1 );
 }
 


### PR DESCRIPTION
Fixes #184

This update uses the `XDEBUG_CONFIG` environment variable to set two things:

- `idekey`: this enables xdebug for every run of PHP and handles setting the cookie if not already present
- `remote_host`: `host.docker.internal` is a special value for Windows and Mac only, Linux distros can use the static IP 172.17.0.1 to communicate with the host machine

Because xdebug is switched on or off by switching container I think its ok to run every time. This has the added benefit of being able to use xdebug with CLI commands.