### PR TITLE
[Backport v3-branch] Ensure XDebug is always on

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,7 +51,9 @@ x-php: &php
     PHP_SENDMAIL_PATH: /usr/sbin/sendmail -t -i -S mailhog:1025
     ALTIS_ANALYTICS_PINPOINT_ENDPOINT: https://pinpoint-${COMPOSE_PROJECT_NAME:-default}.altis.dev
     ALTIS_ANALYTICS_COGNITO_ENDPOINT: https://cognito-${COMPOSE_PROJECT_NAME:-default}.altis.dev
+    # Setting required for minimal config in PHPStorm
     PHP_IDE_CONFIG: serverName=${COMPOSE_PROJECT_NAME:-default}.altis.dev
+    # Enables XDebug for all processes and allows setting remote_host externally for Linux support
     XDEBUG_CONFIG: idekey=${COMPOSE_PROJECT_NAME:-default}.altis.dev remote_host=${XDEBUG_REMOTE_HOST:-host.docker.internal}
 
 x-analytics: &analytics

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -52,7 +52,7 @@ x-php: &php
     ALTIS_ANALYTICS_PINPOINT_ENDPOINT: https://pinpoint-${COMPOSE_PROJECT_NAME:-default}.altis.dev
     ALTIS_ANALYTICS_COGNITO_ENDPOINT: https://cognito-${COMPOSE_PROJECT_NAME:-default}.altis.dev
     PHP_IDE_CONFIG: serverName=${COMPOSE_PROJECT_NAME:-default}.altis.dev
-    XDEBUG_CONFIG: idekey=${COMPOSE_PROJECT_NAME:-default}.altis.dev
+    XDEBUG_CONFIG: idekey=${COMPOSE_PROJECT_NAME:-default}.altis.dev remote_host=${XDEBUG_REMOTE_HOST:-host.docker.internal}
 
 x-analytics: &analytics
   ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,7 +21,8 @@ x-php: &php
     - "proxy:${COMPOSE_PROJECT_NAME:-default}.altis.dev"
   volumes:
     - "${VOLUME}:/usr/src/app:delegated"
-    - "${PWD}/php.ini:/usr/local/etc/php/conf.d/altis.ini"
+    # Use zzz as a prefix to ensure the php.ini overrides are loaded last
+    - "${PWD}/php.ini:/usr/local/etc/php/conf.d/zzz-altis.ini"
     - socket:/var/run/php-fpm
   environment:
     HOST_PATH: ${VOLUME}
@@ -50,8 +51,8 @@ x-php: &php
     PHP_SENDMAIL_PATH: /usr/sbin/sendmail -t -i -S mailhog:1025
     ALTIS_ANALYTICS_PINPOINT_ENDPOINT: https://pinpoint-${COMPOSE_PROJECT_NAME:-default}.altis.dev
     ALTIS_ANALYTICS_COGNITO_ENDPOINT: https://cognito-${COMPOSE_PROJECT_NAME:-default}.altis.dev
-    PHP_XDEBUG_ENABLED:
     PHP_IDE_CONFIG: serverName=${COMPOSE_PROJECT_NAME:-default}.altis.dev
+    XDEBUG_CONFIG: idekey=${COMPOSE_PROJECT_NAME:-default}.altis.dev
 
 x-analytics: &analytics
   ports:

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -2,3 +2,7 @@
 
 # Set sendmail to use mailhog.
 sendmail_path = ${PHP_SENDMAIL_PATH}
+
+# XDebug
+xdebug.default_enable = 1
+xdebug.remote_connect_back = 1

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -2,7 +2,3 @@
 
 # Set sendmail to use mailhog.
 sendmail_path = ${PHP_SENDMAIL_PATH}
-
-# XDebug
-xdebug.default_enable = 1
-xdebug.remote_connect_back = 1

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -2,3 +2,6 @@
 
 # Set sendmail to use mailhog.
 sendmail_path = ${PHP_SENDMAIL_PATH}
+
+# XDebug
+xdebug.default_enable = 1

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -108,7 +108,7 @@ EOT
 		if ( $input->getOption( 'xdebug' ) ) {
 			$env['PHP_IMAGE'] = 'humanmade/altis-local-server-php:3.1.0-dev';
 			if ( in_array( php_uname( 's' ), [ 'BSD', 'Linux', 'Solaris', 'Unknown' ], true ) ) {
-				$env['XEBUG_REMOTE_HOST'] = '172.17.0.1';
+				$env['XDEBUG_REMOTE_HOST'] = '172.17.0.1';
 			}
 		}
 

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -107,6 +107,7 @@ EOT
 
 		if ( $input->getOption( 'xdebug' ) ) {
 			$env['PHP_IMAGE'] = 'humanmade/altis-local-server-php:3.1.0-dev';
+			// phpcs:ignore PHPCompatibility.Constants.NewConstants.php_os_familyFound
 			if ( in_array( PHP_OS_FAMILY, [ 'BSD', 'Linux', 'Solaris', 'Unknown' ], true ) ) {
 				$env['XEBUG_REMOTE_HOST'] = '172.17.0.1';
 			}

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -107,7 +107,6 @@ EOT
 
 		if ( $input->getOption( 'xdebug' ) ) {
 			$env['PHP_IMAGE'] = 'humanmade/altis-local-server-php:3.1.0-dev';
-			$env['PHP_XDEBUG_ENABLED'] = true;
 		}
 
 		$compose = new Process( 'docker-compose up -d', 'vendor/altis/local-server/docker', $env );

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -107,8 +107,7 @@ EOT
 
 		if ( $input->getOption( 'xdebug' ) ) {
 			$env['PHP_IMAGE'] = 'humanmade/altis-local-server-php:3.1.0-dev';
-			// phpcs:ignore PHPCompatibility.Constants.NewConstants.php_os_familyFound
-			if ( in_array( PHP_OS_FAMILY, [ 'BSD', 'Linux', 'Solaris', 'Unknown' ], true ) ) {
+			if ( in_array( php_uname( 's' ), [ 'BSD', 'Linux', 'Solaris', 'Unknown' ], true ) ) {
 				$env['XEBUG_REMOTE_HOST'] = '172.17.0.1';
 			}
 		}

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -107,6 +107,9 @@ EOT
 
 		if ( $input->getOption( 'xdebug' ) ) {
 			$env['PHP_IMAGE'] = 'humanmade/altis-local-server-php:3.1.0-dev';
+			if ( in_array( PHP_OS_FAMILY, [ 'BSD', 'Linux', 'Solaris', 'Unknown' ], true ) ) {
+				$env['XEBUG_REMOTE_HOST'] = '172.17.0.1';
+			}
 		}
 
 		$compose = new Process( 'docker-compose up -d', 'vendor/altis/local-server/docker', $env );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -76,11 +76,6 @@ function bootstrap() {
 		define( 'ALTIS_ANALYTICS_COGNITO_ENDPOINT', getenv( 'ALTIS_ANALYTICS_COGNITO_ENDPOINT' ) );
 	}
 
-	// Set XDebug cookie if environment variable is set.
-	if ( getenv( 'PHP_XDEBUG_ENABLED' ) ) {
-		setcookie( 'XDEBUG_SESSION', $_SERVER['HTTP_HOST'], strtotime( '+1 year' ), '/', $_SERVER['HTTP_HOST'] );
-	}
-
 	add_filter( 'qm/output/file_path_map', __NAMESPACE__ . '\\set_file_path_map', 1 );
 }
 


### PR DESCRIPTION
Backporting #185 

------------------------------------

Fixes #184

This changes from manually setting the XDEBUG_SESSION cookie and relying remote enabling in favour of setting the XDEBUG_CONFIG environment variable. This will ensure that the debugger connects every time and will handle setting the cookie itself.

This also means XDebug can be used to debug CLI commands.

Given that local server has 2 separate modes, with & without xdebug having it always be on in xdebug mode is worth the performance hit as developers can easily switch back.