### PR TITLE
Update Tachyon to 2.3.2

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -203,7 +203,7 @@ services:
       && mc policy set public local/s3-${COMPOSE_PROJECT_NAME:-default}
       && mc mirror --watch --overwrite local/s3-${COMPOSE_PROJECT_NAME:-default} /content"
   tachyon:
-    image: humanmade/tachyon:2.3.0
+    image: humanmade/tachyon:2.3.2
     ports:
       - "8080"
     networks:


### PR DESCRIPTION
Fixes fallback to origin for gifs. Also adds webp detection support by checking `accept` header which makes media on local much much faster.