### PR TITLE
Add destroy prompt answers

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -272,7 +272,7 @@ EOT
 	 */
 	protected function destroy( InputInterface $input, OutputInterface $output ) {
 		$helper = $this->getHelper( 'question' );
-		$question = new ConfirmationQuestion( 'Are you sure you want to destroy the server?', false );
+		$question = new ConfirmationQuestion( 'Are you sure you want to destroy the server? [y/N] ', false );
 		if ( ! $helper->ask( $input, $output, $question ) ) {
 			return false;
 		}


### PR DESCRIPTION
The destroy question prompt does not tell you what the possible answers are, and also appears to need a space at the end as the answer is added immediately following the question text.