### PR TITLE
Forward COMPOSE_PROJECT_NAME env var to PHP container

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,6 +33,7 @@ x-php: &php
     - proxy
     - default
   environment:
+    COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME:-default}
     HOST_PATH: ${VOLUME}
     DB_HOST: db
     DB_READ_REPLICA_HOST: db-read-replica


### PR DESCRIPTION
We are checking the `COMPOSE_PROJECT_NAME` env var to set the server global `HTTP_HOST` value if it is unset eg. in a CLI command however it is not actually present on the PHP container right now. This fixes that problem.

Fixes #194