### PR TITLE
Fix incorrect regular expression to permit hyphenated-subdomains

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -114,7 +114,7 @@ services:
       - "traefik.port=8080"
       - "traefik.protocol=https"
       - "traefik.docker.network=proxy"
-      - "traefik.frontend.rule=HostRegexp:${COMPOSE_PROJECT_NAME:-default}.altis.dev,{subdomain:[a-z.-_]+}.${COMPOSE_PROJECT_NAME:-default}.altis.dev"
+      - "traefik.frontend.rule=HostRegexp:${COMPOSE_PROJECT_NAME:-default}.altis.dev,{subdomain:[a-z._-]+}.${COMPOSE_PROJECT_NAME:-default}.altis.dev"
   xray:
     image: amazon/aws-xray-daemon:3.0.1
     ports:


### PR DESCRIPTION
The hyphen in .-_ is not treated as a literal hyphen unless it occurs at the end of the [] group. This can be demonstrated in the JS console:

```
'hyphenated-site'.match( /^[a-z.-_]+$/ ) // null
'hyphenated-site'.match( /^[a-z._-]+$/ ) // [ ...results ]
```

Reordering these characters allows hyphenated-subdomains to be matched.