### PR TITLE
Fix use of uploads directory on local server

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -114,8 +114,9 @@ services:
       - "traefik.port=8080"
       - "traefik.protocol=https"
       - "traefik.docker.network=proxy"
-      - "traefik.uploads.frontend.redirect.regex=^https?://(.*?).altis.dev/uploads/(.*)"
-      - "traefik.uploads.frontend.redirect.replacement=https://s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev/uploads/$$2"
+      # Redirect any requests to /uploads to the S3 container frontend.
+      - "traefik.uploads.frontend.redirect.regex=^https?://(?:.*?).altis.dev/uploads/(.*)"
+      - "traefik.uploads.frontend.redirect.replacement=https://s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev/uploads/$$1"
       - "traefik.uploads.frontend.redirect.permanent=true"
       - "traefik.frontend.rule=HostRegexp:${COMPOSE_PROJECT_NAME:-default}.altis.dev,{subdomain:[a-z._-]+}.${COMPOSE_PROJECT_NAME:-default}.altis.dev"
   xray:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -52,7 +52,7 @@ x-php: &php
     AWS_XRAY_DAEMON_HOST: xray
     S3_UPLOADS_ENDPOINT: https://altis.dev/
     S3_UPLOADS_BUCKET: s3-${COMPOSE_PROJECT_NAME:-default}
-    S3_UPLOADS_BUCKET_URL: https://s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev
+    S3_UPLOADS_BUCKET_URL: https://${COMPOSE_PROJECT_NAME:-default}.altis.dev
     S3_UPLOADS_KEY: admin
     S3_UPLOADS_SECRET: password
     S3_UPLOADS_REGION: us-east-1
@@ -115,6 +115,9 @@ services:
       - "traefik.protocol=https"
       - "traefik.docker.network=proxy"
       - "traefik.frontend.rule=HostRegexp:${COMPOSE_PROJECT_NAME:-default}.altis.dev,{subdomain:[a-z.-_]+}.${COMPOSE_PROJECT_NAME:-default}.altis.dev"
+      - "traefik.uploads.frontend.redirect.regex=^https?://(.*?).altis.dev/uploads/(.*)"
+      - "traefik.uploads.frontend.redirect.replacement=https://s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev/uploads/$$2"
+      - "traefik.uploads.frontend.redirect.permanent=true"
   xray:
     image: amazon/aws-xray-daemon:3.0.1
     ports:


### PR DESCRIPTION
After the change to the cloud module to ensure media paths matched the site's host name it broke local server's assumption that the uploads path was at `s3-<project>.altis.dev`.

This adds a 301 redirect on the nginx server to map to the correct URL on the S3 container.