### PR TITLE
Fix write permissions when running CLI commands

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -378,10 +378,16 @@ EOT
 		$lines = exec( 'tput lines' );
 		$has_stdin = ! posix_isatty( STDIN );
 		$has_stdout = ! posix_isatty( STDOUT );
+		if ( php_uname( 's' ) === 'Linux' ) {
+			$user = '$UID';
+		} else {
+			$user = 'www-data'
+		}
 		$command = sprintf(
-			'docker exec -e COLUMNS=%d -e LINES=%d -u www-data %s %s %s %s',
+			'docker exec -e COLUMNS=%d -e LINES=%d -u %s %s %s %s %s',
 			$columns,
 			$lines,
+			$user,
 			( ! $has_stdin && ! $has_stdout ) && $program === 'wp' ? '-ti' : '', // forward wp-cli's isPiped detection.
 			$container_id,
 			$program ?? '',

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -174,7 +174,7 @@ EOT
 		$env = $this->get_env();
 		if ( $input->getOption( 'xdebug' ) ) {
 			$env['PHP_IMAGE'] = 'humanmade/altis-local-server-php:3.2.0-dev';
-			if ( in_array( php_uname( 's' ), [ 'BSD', 'Linux', 'Solaris', 'Unknown' ], true ) ) {
+			if ( $this->is_linux() ) {
 				$env['XDEBUG_REMOTE_HOST'] = '172.17.0.1';
 			}
 		}
@@ -378,10 +378,10 @@ EOT
 		$lines = exec( 'tput lines' );
 		$has_stdin = ! posix_isatty( STDIN );
 		$has_stdout = ! posix_isatty( STDOUT );
-		if ( php_uname( 's' ) === 'Linux' ) {
+		if ( $this->is_linux() ) {
 			$user = '$UID';
 		} else {
-			$user = 'www-data'
+			$user = 'www-data';
 		}
 		$command = sprintf(
 			'docker exec -e COLUMNS=%d -e LINES=%d -u %s %s %s %s %s',
@@ -633,5 +633,14 @@ EOT;
 		}
 
 		return preg_replace( '/[^A-Za-z0-9\-\_]/', '', $project_name );
+	}
+
+	/**
+	 * Check if the current host operating system is Linux based.
+	 *
+	 * @return boolean
+	 */
+	protected function is_linux() : bool {
+		return in_array( php_uname( 's' ), [ 'BSD', 'Linux', 'Solaris', 'Unknown' ], true );
 	}
 }


### PR DESCRIPTION
Pass the current user's UID when running on linux, as the mounted volumes are _directly_ accessed from the container. Unlike macOs, where the mounted volumes are is a Docker shared filesystem that correctly maps user permissions.

Fixes #183.