### PR TITLE
Revert "Update Tachyon to 2.3.2"

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -171,7 +171,7 @@ services:
       - "traefik.docker.network=proxy"
       - "traefik.frontend.rule=HostRegexp:s3-${COMPOSE_PROJECT_NAME:-default}.altis.dev;AddPrefix:/s3-${COMPOSE_PROJECT_NAME:-default}"
   tachyon:
-    image: humanmade/tachyon:2.3.2
+    image: humanmade/tachyon:2.2.1
     ports:
       - "8080"
     networks:


### PR DESCRIPTION
Reverts humanmade/altis-local-server#200

Tachyon 2.3.X doesn't support path-style S3 URLs, which is required in Altis V3 (loca-server / fakes3). I think we can do without the gif fixes in v2.3.