### PR TITLE
Allow "altis.dev" TLD to be configured

### DIFF
--- a/docker/conf/traefik.toml
+++ b/docker/conf/traefik.toml
@@ -153,7 +153,6 @@ address = ":8080"
 # Optional
 # Default: ""
 #
-domain = "altis.dev"
 
 # Expose containers by default in traefik
 #

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -55,11 +55,11 @@ class Docker_Compose_Generator {
 	 * @param string $project_name The docker compose project name.
 	 * @param string $root_dir The project root directory.
 	 */
-	public function __construct( string $project_name, string $root_dir ) {
+	public function __construct( string $project_name, string $root_dir, string $tld ) {
 		$this->project_name = $project_name;
 		$this->root_dir = $root_dir;
 		$this->config_dir = dirname( __DIR__, 2 ) . '/docker';
-		$this->tld = 'altis.dev';
+		$this->tld = $tld;
 		$this->hostname = $this->project_name . '.' . $this->tld;
 	}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -34,7 +34,7 @@ function bootstrap() {
 	}
 
 	if ( empty( $_SERVER['HTTP_HOST'] ) ) {
-		$_SERVER['HTTP_HOST'] = getenv( 'COMPOSE_PROJECT_NAME' ) . '.altis.dev';
+		$_SERVER['HTTP_HOST'] = getenv( 'COMPOSE_PROJECT_NAME' ) . '.' . getenv( 'COMPOSE_PROJECT_NAME' );
 	}
 
 	define( 'DB_HOST', getenv( 'DB_HOST' ) );


### PR DESCRIPTION
With the "HTTPS required" natire of `.dev` domains, the fact that we
currently have to issue a fully signed wildcard cert (`.dev` doesn't
support self signed certs), and then the fact that we can't support
subdomain installs in local-server; I think the days of `altis.dev` are
probably numbered. This PR atleast makes this TLD fully configurable, to
something more `.local` or `.altis.local`.

In doing so, I also added an option to set `secure` to `true` / `false`,
so HTTP-only can then be supported with TLDs other than `.dev`.

At this point I don't think we need to publicly document this
neccesarily, but I think we are going to need to move away from this
hardcoding of altis.dev. If nothing else, this makes the code more
configurable in special use cases.
