### PR TITLE
Enable XRay by default

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -647,7 +647,7 @@ class Docker_Compose_Generator {
 			'cavalcade' => true,
 			'elasticsearch' => true,
 			'kibana' => true,
-			'xray' => false,
+			'xray' => true,
 		];
 
 		return array_merge( $defaults, $config );


### PR DESCRIPTION
This was causing problem with the Cloud module's default setting fro XRay so we should avoid errors with a vanilla install. Devs will need to switch off both the cloud module setting and the local server setting to fully turn off xray locally.

Fixes #254