### PR TITLE
Make PHP version configurable

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,3 +65,24 @@ The subdomain used for the project can be configured via the `modules.local-serv
   * `composer server db info` - Print MySQL connection details.
   * `composer server db sequel` - Opens a connection to the database in [Sequel Pro](https://sequelpro.com).
 * `composer server import-uploads` - Syncs files from `content/uploads` to the s3 container.
+
+
+## Configuring the PHP Version
+
+Local Server currently defaults to PHP 7.2. In advance of the PHP 7.4 upgrade coming soon for all Altis sites you can opt-in to using PHP 7.4 for your local environment ahead of time for testing purposes.
+
+To do this add the following your configuration:
+
+```json
+{
+	"extra": {
+		"altis": {
+			"modules": {
+				"local-server": {
+					"php": "7.4"
+				}
+			}
+		}
+	}
+}
+```

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -148,6 +148,11 @@ class Docker_Compose_Generator {
 			],
 		];
 
+		// Opt in to PHP 7.4 usage.
+		if ( $this->get_config()['php'] === '7.4' ) {
+			$services['image'] = 'humanmade/altis-local-server-php:4.0.0-alpha2-dev';
+		}
+
 		if ( $this->get_config()['elasticsearch'] ) {
 			$services['depends_on']['elasticsearch'] = [
 				'condition' => 'service_healthy',
@@ -643,6 +648,7 @@ class Docker_Compose_Generator {
 
 		$config = ( $composer_json['extra']['altis']['modules'][ $module ] ?? [] );
 		$defaults = [
+			'php' => '7.2',
 			'analytics' => true,
 			'cavalcade' => true,
 			'elasticsearch' => true,

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -91,7 +91,7 @@ class Docker_Compose_Generator {
 					'condition' => 'service_started',
 				],
 			],
-			'image' => 'humanmade/altis-local-server-php:4.0.0-alpha2-dev',
+			'image' => 'humanmade/altis-local-server-php:3.4.0-dev',
 			'links' => [
 				'db:db-read-replica',
 				's3:s3.localhost',


### PR DESCRIPTION
We jumped the gun switching Local Server to PHP 7.4 as the cloud environment is not updated yet. This update makes that change configurable so devs can opt-in to the newer version ahead of time but still have the option to work with the existing version.

Fixes #253