### PR TITLE
Disable debug log in favor of default error log

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -123,6 +123,7 @@ class Docker_Compose_Generator {
 				'REDIS_PORT' => 6379,
 				'WP_DEBUG' => 1,
 				'WP_DEBUG_DISPLAY' => 0,
+				'WP_DEBUG_LOG' => 0,
 				'PAGER' => 'more',
 				'HM_ENV_ARCHITECTURE' => 'local-server',
 				'HM_DEPLOYMENT_REVISION' => 'dev',


### PR DESCRIPTION
With WP_DEBUG enabled, calls to `error_log()` are being sent to `content/debug.log` instead of the default error log. This is confusing, as I would expect logs to be visible via `composer serve logs php`. This restores that functionality.