### PR TITLE
Use traefik to pass s3 404s to nginx for fallback handling

### DIFF
--- a/docs/media.md
+++ b/docs/media.md
@@ -1,0 +1,28 @@
+# Local Media
+
+Local Server supports the [Altis Media module](https://www.altis-dxp.com/resources/developer-docs/media/) by replicating the media handling capabilities of a deployed Altis environment. A new Local Server setup will support [Dynamic Images](https://www.altis-dxp.com/resources/developer-docs/media/dynamic-images/) and other media features, and all images you upload will be stored in a local container on your development machine.
+
+When using Local Server to work on an existing Altis site, you may need to pull down a database backup for local testing. Downloading uploaded media along with this database backup may be prohibitively time consuming, or take too much local disk space. Local Server can be configured to request these images directly from an Altis cloud environment.
+
+You can add a file `.config/nginx-additions-media.conf` to your Altis project which instructs Local Server to redirect image requests to a remote server if they were not accessible locally. This preserves your ability to upload and edit local images, while allowing any image file not present in your environment to be loaded from a remote bucket instead.
+
+Assuming that your Altis project uses the name `myproject` and you have confirmed that your environment uses the `us-east-1.tchyn.io` Tachyon URL, your `nginx-additions-media.conf` could look like this:
+
+<pre><code>
+# Listen for Tachyon 404s, and try redirecting those requests to the development S3 bucket.
+location ~* ^/tachyon.+\.(jpe?g|gif|png|webp).*$ {
+	try_files $uri @imageFallback;
+}
+
+location @imageFallback {
+	rewrite ^/tachyon/(.*)$ https://us-east-1.tchyn.io/myproject-development/uploads/$1 break;
+}
+</code></pre>
+
+Alternatively, for read-only image support you can define the constants `S3_UPLOADS_BUCKET`, `S3_UPLOADS_KEY`, `S3_UPLOADS_BUCKET_URL`, `S3_UPLOADS_REGION`, `S3_UPLOADS_SECRET`, and `TACHYON_URL`, to point your Local Server instance at a remote Tachyon instance. You will not be able to upload or edit images, but your local site should display as expected using the remote image server.
+
+Open a support ticket for assistance in determining the specific values and URLs necessary to configure either of these image fallback options on your site.
+
+## Refreshing Local Media
+
+If you chose to download images to your `uploads/` folder instead of using one of the above remote fallback approaches, you may need to signal Local Server to synchronize your local files with the image service. To run a local image sync, use the command `composer server import-uploads`.

--- a/docs/media.md
+++ b/docs/media.md
@@ -15,7 +15,7 @@ location ~* ^/tachyon.+\.(jpe?g|gif|png|webp).*$ {
 }
 
 location @imageFallback {
-	rewrite ^/tachyon/(.*)$ https://us-east-1.tchyn.io/myproject-development/uploads/$1 break;
+	rewrite ^/tachyon/(.*)$ https://myproject.altis.cloud/tachyon/$1 break;
 }
 </code></pre>
 

--- a/docs/media.md
+++ b/docs/media.md
@@ -1,6 +1,6 @@
 # Local Media
 
-Local Server supports the [Altis Media module](https://www.altis-dxp.com/resources/developer-docs/media/) by replicating the media handling capabilities of a deployed Altis environment. A new Local Server setup will support [Dynamic Images](https://www.altis-dxp.com/resources/developer-docs/media/dynamic-images/) and other media features, and all images you upload will be stored in a local container on your development machine.
+Local Server supports the [Altis Media module](docs://media/) by replicating the media handling capabilities of a deployed Altis environment. A new Local Server setup will support [Dynamic Images](docs://media/dynamic-images/) and other media features, and all images you upload will be stored in a local container on your development machine.
 
 When using Local Server to work on an existing Altis site, you may need to pull down a database backup for local testing. Downloading uploaded media along with this database backup may be prohibitively time consuming, or take too much local disk space. Local Server can be configured to request these images directly from an Altis cloud environment.
 

--- a/docs/media.md
+++ b/docs/media.md
@@ -19,9 +19,7 @@ location @imageFallback {
 }
 </code></pre>
 
-Alternatively, for read-only image support you can define the constants `S3_UPLOADS_BUCKET`, `S3_UPLOADS_KEY`, `S3_UPLOADS_BUCKET_URL`, `S3_UPLOADS_REGION`, `S3_UPLOADS_SECRET`, and `TACHYON_URL`, to point your Local Server instance at a remote Tachyon instance. You will not be able to upload or edit images, but your local site should display as expected using the remote image server.
-
-Open a support ticket for assistance in determining the specific values and URLs necessary to configure either of these image fallback options on your site.
+Your production Tachyon URL will be whatever the primary domain name for the stack is plus the path `/tachyon/` so it may not always look like the example above.
 
 ## Refreshing Local Media
 

--- a/docs/media.md
+++ b/docs/media.md
@@ -6,7 +6,7 @@ When using Local Server to work on an existing Altis site, you may need to pull 
 
 You can add a file `.config/nginx-additions-media.conf` to your Altis project which instructs Local Server to redirect image requests to a remote server if they were not accessible locally. This preserves your ability to upload and edit local images, while allowing any image file not present in your environment to be loaded from a remote bucket instead.
 
-Assuming that your Altis project uses the name `myproject` and you have confirmed that your environment uses the `us-east-1.tchyn.io` Tachyon URL, your `nginx-additions-media.conf` could look like this:
+Assuming that your Altis project uses the name `myproject` for Local Server and your environment uses the domain name `myproject.altis.cloud`, your `nginx-additions-media.conf` could look like this:
 
 <pre><code>
 # Listen for Tachyon 404s, and try redirecting those requests to the development S3 bucket.

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -222,7 +222,7 @@ class Docker_Compose_Generator {
 					'traefik.protocol=https',
 					'traefik.docker.network=proxy',
 					"traefik.frontend.rule=HostRegexp:{$this->hostname},{subdomain:[a-z.-_]+}.{$this->hostname}",
-					"traefik.backend=nginx-{$this->hostname}",
+					"traefik.backend=nginx-{$this->project_name}",
 				],
 			],
 		];
@@ -418,7 +418,7 @@ class Docker_Compose_Generator {
 					// Point s3 404s (which probably represent missing files in Tachyon)
 					// to Nginx to allow projects to implement custom fallback behavior.
 					'traefik.frontend.errors.tachyon.status=404',
-					"traefik.frontend.errors.tachyon.backend=nginx-{$this->hostname}",
+					"traefik.frontend.errors.tachyon.backend=nginx-{$this->project_name}",
 				],
 			],
 			's3-sync-to-host' => [

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -222,7 +222,7 @@ class Docker_Compose_Generator {
 					'traefik.protocol=https',
 					'traefik.docker.network=proxy',
 					"traefik.frontend.rule=HostRegexp:{$this->hostname},{subdomain:[a-z.-_]+}.{$this->hostname}",
-					'traefik.backend=nginx',
+					"traefik.backend=nginx-{$this->hostname}",
 				],
 			],
 		];
@@ -418,7 +418,7 @@ class Docker_Compose_Generator {
 					// Point s3 404s (which probably represent missing files in Tachyon)
 					// to Nginx to allow projects to implement custom fallback behavior.
 					'traefik.frontend.errors.tachyon.status=404',
-					'traefik.frontend.errors.tachyon.backend=nginx',
+					"traefik.frontend.errors.tachyon.backend=nginx-{$this->hostname}",
 				],
 			],
 			's3-sync-to-host' => [

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -222,6 +222,7 @@ class Docker_Compose_Generator {
 					'traefik.protocol=https',
 					'traefik.docker.network=proxy',
 					"traefik.frontend.rule=HostRegexp:{$this->hostname},{subdomain:[a-z.-_]+}.{$this->hostname}",
+					'traefik.backend=nginx',
 				],
 			],
 		];
@@ -414,6 +415,10 @@ class Docker_Compose_Generator {
 					'traefik.protocol=http',
 					'traefik.docker.network=proxy',
 					"traefik.frontend.rule=HostRegexp:s3-{$this->hostname}",
+					// Point s3 404s (which probably represent missing files in Tachyon)
+					// to Nginx to allow projects to implement custom fallback behavior.
+					"traefik.frontend.errors.tachyon.status=404",
+					"traefik.frontend.errors.tachyon.backend=nginx",
 				],
 			],
 			's3-sync-to-host' => [

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -417,8 +417,8 @@ class Docker_Compose_Generator {
 					"traefik.frontend.rule=HostRegexp:s3-{$this->hostname}",
 					// Point s3 404s (which probably represent missing files in Tachyon)
 					// to Nginx to allow projects to implement custom fallback behavior.
-					"traefik.frontend.errors.tachyon.status=404",
-					"traefik.frontend.errors.tachyon.backend=nginx",
+					'traefik.frontend.errors.tachyon.status=404',
+					'traefik.frontend.errors.tachyon.backend=nginx',
 				],
 			],
 			's3-sync-to-host' => [


### PR DESCRIPTION
For a while now we've been looking for a way to implement something akin to [Chassis `media_fallback`](https://github.com/chassis/media_fallback) within local server. This is a useful and important ability because it would let Altis site developers get their local up and running quickly using only a database dump, without also having to clone down potentially hundreds upon hundreds of media files.

Setting a local to use a production s3 bucket isn't ideal, because then developers cannot upload files to the local environment for testing. I feel that the most flexible setup would be to permit normal local file handling but then to conditionally redirect media 404's to nginx, so that we can use `nginx-additions` to catch those 404s and attempt to redirect them to a production file.

Adding an error fallback to the `tachyon` service didn't seem to do the trick, but after logging the request flow in traefik I was able to get 404s to consistently show up in nginx by setting these rules on the minio container. Once I got that working, then with the lines below in `nginx-additions.conf`

```nginx
location ~* ^/tachyon.+\.(jpe?g|gif|png|webp).*$ {
	try_files $uri @productionImages;
}

location @productionImages {
	rewrite ^/tachyon/(.*)$ https://{tachyon service domain}/{app name}/uploads/$1 break;
}
```
seems to do what I want; but without changes here in local-server, this behavior won't be possible.

I'd welcome feedback on the approach and my solution to it.