### PR TITLE
Expand logging instructions to explain underlying docker commands

### DIFF
--- a/docs/viewing-logs.md
+++ b/docs/viewing-logs.md
@@ -1,3 +1,5 @@
 # Viewing Logs
 
 Often you'll want to access logs from the services that Local Server provides. For example, PHP Errors Logs, Nginx Access Logs, or MySQL Logs. To do so, run the `composer server logs <service>` command. `<service>` can be any of `php`, `nginx`, `db`, `elasticsearch`, `s3`, `xray`, `cavalcade` or `redis`. This command will tail the logs (live update). To exit the log view, press `Ctrl+C`.
+
+Local Server provides these commands as aliases to the underlying `docker log` command, so you may alternatively list out running containers with `docker ps` and then follow the logs for any individual running container. This lets you monitor logs from any working directory without relying on the `composer server` alias. To monitor the logs of the Traefik proxy which routes requests between multiple Local Server instances, for example, you would run `docker logs docker_proxy_1 --follow`.


### PR DESCRIPTION
While working on #263 I was a bit stuck before @roborourke explained how to directly access Traefik logs via docker. Once I understood how that logging command works, I found it more useful to directly follow the logs using `docker` commands because it removed some of the boilerplate text from the output and let me see more data at once. I think it would be useful to be explicit about how the logging command works under the hood to de-obfuscate this for developers who may need to dive deeper.