### PR TITLE
Add a `mysql:` link to the database connection information output

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -19,6 +19,7 @@ Host:           0.0.0.0
 Port:           32775
 
 Version:        5.7.26-1debian9
+MySQL link:     mysql://wordpress:wordpress@0.0.0.0:32775/wordpress
 ```
 
 Use `composer server db sequel` to open the database in Sequel Pro. This command can only be run under MacOS and requires [Sequel Pro](https://www.sequelpro.com/) to be installed on your computer.

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -523,6 +523,7 @@ EOT
 <info>Port</info>:           ${connection_data['PORT']}
 
 <comment>Version</comment>:        ${connection_data['MYSQL_VERSION']}
+<comment>MySQL link</comment>:     mysql://${connection_data['MYSQL_USER']}:${connection_data['MYSQL_PASSWORD']}@${connection_data['HOST']}:${connection_data['PORT']}/${connection_data['MYSQL_DATABASE']}
 
 EOT;
 				$output->write( $db_info );


### PR DESCRIPTION
If you use a local MySQL client that supports the `mysql:` protocol but not the Sequel Pro `.spf` file format, for example [TablePlus](https://tableplus.com/), having this link present in the database connection details output allows you to connect straight to the local server database in that client (eg. by cmd+clicking the link in the terminal).