### PR TITLE
Introduce "exec" subcommand for "composer server db"

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -23,3 +23,9 @@ MySQL link:     mysql://wordpress:wordpress@0.0.0.0:32775/wordpress
 ```
 
 Use `composer server db sequel` to open the database in Sequel Pro. This command can only be run under MacOS and requires [Sequel Pro](https://www.sequelpro.com/) to be installed on your computer.
+
+Use `composer server db exec -- "<command>"` to execute and output the results of an arbitrary SQL command:
+
+```sh
+composer server db exec -- 'select id,post_title from wordpress.wp_posts limit 2;'
+```

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -70,6 +70,7 @@ Database commands:
 	db                            Log into MySQL on the Database server
 	db sequel                     Generates an SPF file for Sequel Pro
 	db info                       Prints out Database connection details
+	db exec -- "<query>"          Run and output the result of a SQL query.
 View the logs
 	logs <service>                <service> can be php, nginx, db, s3, elasticsearch, xray
 Import files from content/uploads directly to s3:
@@ -549,6 +550,18 @@ EOT;
 					$output->writeln( '<error>You must have Sequel Pro (https://www.sequelpro.com) installed to use this command</error>' );
 				}
 
+				break;
+			case 'exec':
+				$query = $input->getArgument( 'options' )[1] ?? null;
+				if ( empty( $query ) ) {
+					$output->writeln( '<error>No query specified: pass a query via `db exec -- "sql query..."`</error>' );
+					break;
+				}
+				if ( substr( $query, -1 ) !== ';' ) {
+					$query = "$query;";
+				}
+				// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
+				passthru( "$base_command mysql --database=wordpress --user=root -pwordpress -e \"$query\"", $return_val );
 				break;
 			case null:
 				// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled


### PR DESCRIPTION
I'm finding that I miss the ability to execute arbitrary sql commands and output the results to a local file. Enhancing the `db` command to accept an `exec` subcommand, which can take a string query like you would use directly with `mysql -e`, makes this easy without having to go via `db info` and then use the `mysql` command directly.