### PR TITLE
Docs: Use markdown for code formatting

### DIFF
--- a/docs/elasticsearch.md
+++ b/docs/elasticsearch.md
@@ -39,11 +39,11 @@ The ElasticSearch hostname is not directly exposed however you can find the dyna
 
 You should see output similar to this:
 
-<pre><code>
-project_elasticsearch_1   /elastic-entrypoint.sh ela ...   Up (healthy)   <strong>0.0.0.0:32871</strong>->9200/tcp, 9300/tcp
-</code></pre>
+```
+project_elasticsearch_1   /elastic-entrypoint.sh ela ...   Up (healthy)   0.0.0.0:32871->9200/tcp, 9300/tcp
+```
 
-Copy the mapped IP and port (highlighted in bold above) and use it to query ElasticSearch directly:
+Copy the mapped IP and port (`0.0.0.0:32871` in the example above) and use it to query ElasticSearch directly:
 
 ```
 curl -XGET http://0.0.0.0:32871


### PR DESCRIPTION
The `<code>` block used on the ElasticSearch page is being stripped out of the generated docs on the [Documentation site](https://docs.altis-dxp.com/local-server/elasticsearch/).

Docs:
![Screenshot 2021-05-11 at 11 24 43](https://user-images.githubusercontent.com/5014023/117801710-84c9ac00-b24c-11eb-8a3a-09a086550bab.png)

GH:
![Screenshot 2021-05-11 at 11 32 50](https://user-images.githubusercontent.com/5014023/117802849-dc1c4c00-b24d-11eb-96a8-844a81a54089.png)

This PR changes the wording of the documentation so the bold formatting inside the code block is no longer required, and regular markdown can be used.

![Screenshot 2021-05-11 at 11 43 22](https://user-images.githubusercontent.com/5014023/117803068-1e458d80-b24e-11eb-8143-5cf050c2602c.png)

