### PR TITLE
Allow to customize php image from ENV

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,7 @@ x-php: &php
       condition: service_started
     mailhog:
       condition: service_started
-  image: humanmade/altis-local-server-php:3.2.0
+  image: ${PHP_IMAGE:-humanmade/altis-local-server-php:3.2.0}
   links:
     - "db:db-read-replica"
     - "s3:s3.localhost"

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -146,6 +146,7 @@ EOT
 			'COMPOSE_PROJECT_NAME' => $this->get_project_subdomain(),
 			'PATH' => getenv( 'PATH' ),
 			'ES_MEM_LIMIT' => getenv( 'ES_MEM_LIMIT' ) ?: '1g',
+			'PHP_IMAGE' => getenv( 'PHP_IMAGE' ) ?: 'humanmade/altis-local-server-php:3.2.0',
 		];
 	}
 

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -174,7 +174,8 @@ EOT
 
 		$env = $this->get_env();
 		if ( $input->getOption( 'xdebug' ) ) {
-			$env['PHP_IMAGE'] = 'humanmade/altis-local-server-php:3.2.0-dev';
+			$env['PHP_IMAGE'] = isset( $env['PHP_IMAGE'] ) ?
+				$env['PHP_IMAGE'] . '-dev' : 'humanmade/altis-local-server-php:3.2.0-dev';
 			if ( $this->is_linux() ) {
 				$env['XDEBUG_REMOTE_HOST'] = '172.17.0.1';
 			}


### PR DESCRIPTION
Since we upgrade to use PHP 7.4 as the runtime on production. But we are still on Altis v5 which by default using PHP 7.2 from the docker image `humanmade/altis-local-server-php:3.2.0`

This PR only target `altis/local-server` version 5.x only.

To use new PHP image we can run with:
`PHP_IMAGE=humanmade/altis-local-server-php:4.0.0 composer server start`
