### PR TITLE
Add COMPOSE_PROJECT_NAME env to php instance

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -114,6 +114,7 @@ class Docker_Compose_Generator {
 			],
 			'environment' => [
 				'HOST_PATH' => $this->root_dir,
+				'COMPOSE_PROJECT_NAME' => $this->hostname,
 				'DB_HOST' => 'db',
 				'DB_READ_REPLICA_HOST' => 'db-read-replica',
 				'DB_PASSWORD' => 'wordpress',


### PR DESCRIPTION
When I tried to upgrade the local-server to v7.0.1, throwing an error when I run wp-cli command:
```
bash-5.0$ wp option get siteurl
Error: Site '.altis.dev/' not found. Verify DOMAIN_CURRENT_SITE matches an existing site or use `--url=<url>` to override.
```

This is because we set the host when it is empty here: 
https://github.com/humanmade/altis-local-server/blob/master/inc/namespace.php#L36-L38

But the `COMPOSE_PROJECT_NAME` doesn't exist in php instance environment, it exist in docker-compose command only.
This PR fixed that.