### PR TITLE
Fix default HTTP_HOST value

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -34,7 +34,7 @@ function bootstrap() {
 	}
 
 	if ( empty( $_SERVER['HTTP_HOST'] ) ) {
-		$_SERVER['HTTP_HOST'] = getenv( 'COMPOSE_PROJECT_NAME' ) . '.altis.dev';
+		$_SERVER['HTTP_HOST'] = getenv( 'COMPOSE_PROJECT_NAME' );
 	}
 
 	define( 'DB_HOST', getenv( 'DB_HOST' ) );


### PR DESCRIPTION
The `.altis.dev` suffix is not required, follow on from #298 