### PR TITLE
Support for Linux on WSL

### DIFF
--- a/docs/using-xdebug.md
+++ b/docs/using-xdebug.md
@@ -60,10 +60,11 @@ Xdebug is configured to connect to the default port 9003 so there should be a mi
 
 ### VSCode
 
+1. Install a [PHP Debug extension](https://github.com/xdebug/vscode-php-debug)
 1. Open the debug tab (the bug icon on the menu sidebar).
-2. In the dropdown menu at the top of the left hand side bar choose "Add configuration".
-3. In the popup that appears select "PHP" as your environment.
-4. You will be taken a new file called `.vscode/launch.json` with the default settings:
+1. In the dropdown menu at the top of the left hand side bar choose "Add configuration".
+1. In the popup that appears select "PHP" as your environment.
+1. You will be taken a new file called `.vscode/launch.json` with the default settings:
    ```json
    {
      "version": "0.2.0",
@@ -80,12 +81,12 @@ Xdebug is configured to connect to the default port 9003 so there should be a mi
          "request": "launch",
          "program": "${file}",
          "cwd": "${fileDirname}",
-         "port": 9003,
+         "port": 9003
        }
      ]
    }
    ```
-5. Add the following `pathMappings` property to each configuration:
+1. Add the following `hostname` and `pathMappings` property to each configuration:
    ```json
    {
      "version": "0.2.0",
@@ -95,6 +96,7 @@ Xdebug is configured to connect to the default port 9003 so there should be a mi
          "type": "php",
          "request": "launch",
          "port": 9003,
+         "hostname": "0.0.0.0",
          "pathMappings": {
            "/usr/src/app": "${workspaceRoot}"
          }
@@ -106,6 +108,7 @@ Xdebug is configured to connect to the default port 9003 so there should be a mi
          "program": "${file}",
          "cwd": "${fileDirname}",
          "port": 9003,
+         "hostname": "0.0.0.0",
          "pathMappings": {
            "/usr/src/app": "${workspaceRoot}"
          }
@@ -113,7 +116,7 @@ Xdebug is configured to connect to the default port 9003 so there should be a mi
      ]
    }
    ```
-6. You are done, click the green play button to start the debug client.
+1. You are done, click the green play button to start the debug client.
 
 For more information on the available configuration options, including Xdebug settings, [view the VSCode Debugging documentation here](https://go.microsoft.com/fwlink/?linkid=830387).
 

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -727,6 +727,24 @@ EOT;
 	}
 
 	/**
+	 * Check if the current host is Windows.
+	 *
+	 * @return boolean
+	 */
+	public static function is_windows() : bool {
+		return php_uname( 's' ) === 'Windows';
+	}
+
+	/**
+	 * Check if the current host is WSL.
+	 *
+	 * @return boolean
+	 */
+	public static function is_wsl() : bool {
+		return ! empty( $_ENV['WSL_INTEROP'] );
+	}
+
+	/**
 	 * Check if Mutagen is installed.
 	 *
 	 * @return boolean

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -741,7 +741,7 @@ EOT;
 	 * @return boolean
 	 */
 	public static function is_wsl() : bool {
-		return ! empty( $_ENV['WSL_INTEROP'] );
+		return getenv( 'WSL_INTEROP' ) !== false;
 	}
 
 	/**

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -141,7 +141,10 @@ class Docker_Compose_Generator {
 				'ALTIS_ANALYTICS_PINPOINT_ENDPOINT' => "https://pinpoint-{$this->hostname}",
 				'ALTIS_ANALYTICS_COGNITO_ENDPOINT' => "https://cognito-{$this->hostname}",
 				// Enables XDebug for all processes and allows setting remote_host externally for Linux support.
-				'XDEBUG_CONFIG' => sprintf( 'client_host=%s', Command::is_linux() ? '172.17.0.1' : 'host.docker.internal' ),
+				'XDEBUG_CONFIG' => sprintf(
+					'client_host=%s',
+					Command::is_linux() && ! Command::is_wsl() ? '172.17.0.1' : 'host.docker.internal'
+				),
 				'PHP_IDE_CONFIG' => "serverName={$this->hostname}",
 				'XDEBUG_SESSION' => $this->hostname,
 				// Set XDebug mode, fall back to "off" to avoid any performance hits.


### PR DESCRIPTION
Linux on WSL can still use the `host.docker.internal` host name to resolve the Docker VM, so we need to account for that too when switching between the Docker Engine IP used in Linux vs Linux on WSL.