### PR TITLE
Use docker exec for shell

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -478,11 +478,19 @@ EOT
 		$columns = exec( 'tput cols' );
 		$lines = exec( 'tput lines' );
 		$command_prefix = $this->get_base_command_prefix();
+
+		$php_container_id = shell_exec( sprintf(
+			'%s %s',
+			$command_prefix,
+			$this->get_compose_command( 'ps -q php' )
+		) );
+
 		passthru( sprintf(
-			"$command_prefix %s exec -e COLUMNS=%d -e LINES=%d php /bin/bash",
-			$this->get_compose_command(),
+			"$command_prefix %s exec -it -e COLUMNS=%d -e LINES=%d %s /bin/bash",
+			'docker',
 			$columns,
-			$lines
+			$lines,
+			trim( $php_container_id )
 		), $return_val );
 
 		return $return_val;


### PR DESCRIPTION
`composer server start` is starting bash in non-interactive mode (i.e. `echo $-i` does not have the `i` flag). This appears to be caused by a difference in `docker compose exec` vs the old `docker-compose exec`.

`docker compose exec` doesn't support interactive/TTY flags (-it), while `docker exec` does. (See https://stackoverflow.com/a/36265910/2575) I've switched this to instead look up the container ID, and use `docker exec` directly for the shell instead.

This might need error handling for if there's no container ID, but the other place we use `ps -q` (for the DB) we don't check, so not sure on that.