### PR TITLE
Align output of stop with start

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -279,11 +279,15 @@ EOT
 		$output->writeln( '<info>Stopping...</>' );
 
 		$compose = new Process( $this->get_compose_command( 'stop', true ), 'vendor', $this->get_env() );
+		$compose->setTty( true );
+		$compose->setTimeout( 0 );
 		$return_val = $compose->run( function ( $type, $buffer ) {
 			echo $buffer;
 		} );
 
 		$proxy = new Process( $this->get_compose_command( '-f proxy.yml stop' ), 'vendor/altis/local-server/docker' );
+		$proxy->setTimeout( 0 );
+		$proxy->setTty( true );
 		$proxy->run( function ( $type, $buffer ) {
 			echo $buffer;
 		} );


### PR DESCRIPTION
Currently, the `composer server stop` command is not using TTY. This means that I would see this in my terminal:

```
$ composer server stop
Stopping...
Stopping my-project_nginx_1           ... 
Stopping my-project_cavalcade_1       ...
Stopping my-project_s3-sync-to-host_1 ...
Stopping my-project_php_1             ...
Stopping my-project_kibana_1          ...
Stopping my-project_s3_1              ...
Stopping my-project_elasticsearch_1   ...
Stopping my-project_xray_1            ...
Stopping my-project_mailhog_1         ...
Stopping my-project_tachyon_1         ...
Stopping my-project_cognito_1         ...
Stopping my-project_redis_1           ...
Stopping my-project_pinpoint_1        ...
Stopping my-project_db_1              ...
Stopping my-project_s3-sync-to-host_1 ... done
Stopping my-project_xray_1            ... done
Stopping my-project_cavalcade_1       ... done
Stopping my-project_cognito_1         ... done
Stopping my-project_pinpoint_1        ... done
Stopping my-project_nginx_1           ... done
Stopping my-project_php_1             ... done
Stopping my-project_redis_1           ... done
Stopping my-project_mailhog_1         ... done
Stopping my-project_db_1              ... done
Stopping my-project_s3_1              ... done
Stopping my-project_tachyon_1         ... done
Stopping my-project_kibana_1          ... done
Stopping my-project_elasticsearch_1   ... done
Stopping docker_proxy_1 ... 
Stopping docker_proxy_1 ... done
Stopped.
```

This PR aligns the `stop` command with the `start` one, updating it to use TTY and no timeout.

This results in the following output, where each container is updating its own line:

```
$ composer server stop
Stopping...
Stopping my-project_nginx_1           ... done
Stopping my-project_cavalcade_1       ... done
Stopping my-project_s3-sync-to-host_1 ... done
Stopping my-project_php_1             ... done
Stopping my-project_kibana_1          ... done
Stopping my-project_s3_1              ... done
Stopping my-project_elasticsearch_1   ... done
Stopping my-project_xray_1            ... done
Stopping my-project_mailhog_1         ... done
Stopping my-project_tachyon_1         ... done
Stopping my-project_cognito_1         ... done
Stopping my-project_redis_1           ... done
Stopping my-project_pinpoint_1        ... done
Stopping my-project_db_1              ... done
Stopping docker_proxy_1 ... done
Stopped.
```