### PR TITLE
Default to ES 7 rather than 6.8

### DIFF
--- a/docs/elasticsearch.md
+++ b/docs/elasticsearch.md
@@ -4,7 +4,7 @@ ElasticSearch is an integral component of Altis, enabling enhanced search and re
 
 ## Available Versions
 
-Elasticsearch defaults to version 6.8 however you can change the version in your config:
+Elasticsearch defaults to version 7.10 however you can change the version in your config if your cloud environments have not yet been updated and you need to match them:
 
 ```json
 {
@@ -12,7 +12,7 @@ Elasticsearch defaults to version 6.8 however you can change the version in your
 		"altis": {
 			"modules": {
 				"local-server": {
-					"elasticsearch": "7.10"
+					"elasticsearch": "6.8"
 				}
 			}
 		}
@@ -22,8 +22,8 @@ Elasticsearch defaults to version 6.8 however you can change the version in your
 
 The current available versions are:
 
-- 7.10
-- 6.8 (default)
+- 7.10 (default)
+- 6.8
 - 6.3
 
 You can also use the major version on its own to get the latest minor version, for example "6" will resolve to version "6.8".

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -716,7 +716,7 @@ class Docker_Compose_Generator {
 		$defaults = [
 			'analytics' => true,
 			'cavalcade' => true,
-			'elasticsearch' => '6',
+			'elasticsearch' => '7',
 			'kibana' => true,
 			'xray' => true,
 			'ignore-paths' => [],
@@ -735,7 +735,7 @@ class Docker_Compose_Generator {
 			return (string) $this->get_config()['elasticsearch'];
 		}
 
-		return '6';
+		return '7';
 	}
 
 	/**

--- a/load.php
+++ b/load.php
@@ -15,7 +15,7 @@ add_action( 'altis.modules.init', function () {
 		's3' => true,
 		'tachyon' => true,
 		'analytics' => true,
-		'elasticsearch' => 6,
+		'elasticsearch' => '7',
 	];
 
 	Altis\register_module( 'local-server', __DIR__, 'Local Server', $default_settings, __NAMESPACE__ . '\\bootstrap' );


### PR DESCRIPTION
As part of updates to the cloud infrastructure and with Altis supporting ES7 from v5 and up we should have ES 7 as the default from now on.