### PR TITLE
Use max ES container memory limit for Xmx setting

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -182,7 +182,7 @@ EOT
 			'DOCKER_CLIENT_TIMEOUT' => 120,
 			'COMPOSE_HTTP_TIMEOUT' => 120,
 			'PATH' => getenv( 'PATH' ),
-			'ES_MEM_LIMIT' => getenv( 'ES_MEM_LIMIT' ) ?: '2g',
+			'ES_MEM_LIMIT' => getenv( 'ES_MEM_LIMIT' ) ?: '1g',
 			'HOME' => getenv( 'HOME' ),
 		];
 	}

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -182,7 +182,7 @@ EOT
 			'DOCKER_CLIENT_TIMEOUT' => 120,
 			'COMPOSE_HTTP_TIMEOUT' => 120,
 			'PATH' => getenv( 'PATH' ),
-			'ES_MEM_LIMIT' => getenv( 'ES_MEM_LIMIT' ) ?: '1g',
+			'ES_MEM_LIMIT' => getenv( 'ES_MEM_LIMIT' ) ?: '2g',
 			'HOME' => getenv( 'HOME' ),
 		];
 	}

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -294,7 +294,7 @@ class Docker_Compose_Generator {
 	 * @return array
 	 */
 	protected function get_service_elasticsearch() : array {
-		$mem_limit = getenv( 'ES_MEM_LIMIT' ) ?: '2g';
+		$mem_limit = getenv( 'ES_MEM_LIMIT' ) ?: '1g';
 
 		$version_map = [
 			'7.10' => 'humanmade/altis-local-server-elasticsearch:4.1.0',
@@ -349,8 +349,8 @@ class Docker_Compose_Generator {
 					// Force ES into single-node mode (otherwise defaults to zen discovery as
 					// network.host is set in the default config).
 					'discovery.type=single-node',
-					// Reduce from default of 1GB of memory to 512MB.
-					'ES_JAVA_OPTS=-Xms1g -Xmx1g',
+					// Use max container memory limit as the max JVM heap allocation value.
+					"ES_JAVA_OPTS=-Xms512m -Xmx{$mem_limit}",
 				],
 			],
 		];

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -294,7 +294,7 @@ class Docker_Compose_Generator {
 	 * @return array
 	 */
 	protected function get_service_elasticsearch() : array {
-		$mem_limit = getenv( 'ES_MEM_LIMIT' ) ?: '1g';
+		$mem_limit = getenv( 'ES_MEM_LIMIT' ) ?: '2g';
 
 		$version_map = [
 			'7.10' => 'humanmade/altis-local-server-elasticsearch:4.1.0',
@@ -350,7 +350,7 @@ class Docker_Compose_Generator {
 					// network.host is set in the default config).
 					'discovery.type=single-node',
 					// Reduce from default of 1GB of memory to 512MB.
-					'ES_JAVA_OPTS=-Xms512m -Xmx512m',
+					'ES_JAVA_OPTS=-Xms1g -Xmx1g',
 				],
 			],
 		];


### PR DESCRIPTION
A number of analytics queries fail without this increase with an error like the following (truncated):

`{"error":{"root_cause":[{"type":"circuit_breaking_exception","reason":"[parent] Data too large, data for [<reused_arrays>] would be [510575952/486.9mb], which is larger than the limit of [510027366/486.3mb], real usage: [510575872/486.9mb], new bytes reserved: [80/80b], usages [request=464680/453.7kb, fielddata=54107/52.8kb, in_flight_requests=5162/5kb, accounting=3157104/3mb]","bytes_wanted":510575952,"bytes_limit":510027366,"durability":"PERMANENT"},{"type":"circuit_breaking_exception","reason":"[parent] Data too large, data for [<reused_arrays>] would be [510575952/486.9mb], which is larger than the limit of [510027366/486.3mb], real usage: [510575872/486.9mb], new bytes reserved: [80/80b], usages [request=200256/195.5kb, fielddata=54107/52.8kb, in_flight_requests=5162/5kb, accounting=3157104/3mb]","bytes_wanted":510575952,"bytes_limit":510027366,"durability":"PERMANENT"},{"type":"circuit_breaking_exception","reason":"[parent] Data too large, data for [<agg [endpoint.Demographic.Locale]>] would be [510580992/486.9mb], which is larger than the limit of [510027366/486.3mb], real usage: [510575872/486.9mb], new bytes reserved: [5120/5kb], usages [request=73088/71.3kb, fielddata=54693/53.4kb, in_flight_requests=5162/5kb, accounting=3157104/3mb]","bytes_wanted":510580992,"bytes_limit":510027366,"durability":"PERMANENT"},{"type":"circuit_breaking_exception","reason":"[parent] Data too large, data for [<reused_`

We might be able to modify the queries a bit to work with small ES instances, or just generally make the queries less heavy but it will require a good deal of time and effort.