### PR TITLE
Support for ARM64

### DIFF
--- a/docker/minio.json
+++ b/docker/minio.json
@@ -1,5 +1,5 @@
 {
-	"version": "9",
+	"version": "10",
 	"hosts": {
 		"local": {
 			"url": "http://s3:9000",

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -703,7 +703,7 @@ EOT;
 				'--volume=%3$s/vendor/altis/local-server/docker/minio.json:/root/.mc/config.json ' .
 				'--volume=%3$s/content/uploads:/content/uploads:delegated ' .
 				'--network=%4$s_default ' .
-				'minio/mc:RELEASE.2020-03-14T01-23-37Z %5$s',
+				'minio/mc:RELEASE.2021-09-02T09-21-27Z %5$s',
 			$columns,
 			$lines,
 			getcwd(),

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -91,7 +91,7 @@ class Docker_Compose_Generator {
 					'condition' => 'service_started',
 				],
 			],
-			'image' => 'humanmade/altis-local-server-php:edge',
+			'image' => 'humanmade/altis-local-server-php:4.2.0-dev',
 			'links' => [
 				'db:db-read-replica',
 				's3:s3.localhost',
@@ -200,7 +200,7 @@ class Docker_Compose_Generator {
 	protected function get_service_nginx() : array {
 		return [
 			'nginx' => [
-				'image' => 'humanmade/altis-local-server-nginx:edge',
+				'image' => 'humanmade/altis-local-server-nginx:3.4.0',
 				'networks' => [
 					'proxy',
 					'default',
@@ -256,7 +256,7 @@ class Docker_Compose_Generator {
 	protected function get_service_db() : array {
 		return [
 			'db' => [
-				'image' => 'mysql/mysql-server:8.0',
+				'image' => 'biarms/mysql:5.7',
 				'volumes' => [
 					'db-data:/var/lib/mysql',
 				],
@@ -416,7 +416,7 @@ class Docker_Compose_Generator {
 	protected function get_service_s3() : array {
 		return [
 			's3' => [
-				'image' => 'minio/minio:latest',
+				'image' => 'minio/minio:RELEASE.2021-09-18T18-09-59Z',
 				'volumes' => [
 					's3:/data:rw',
 				],
@@ -455,7 +455,7 @@ class Docker_Compose_Generator {
 				],
 			],
 			's3-sync-to-host' => [
-				'image' => 'minio/mc:latest',
+				'image' => 'minio/mc:RELEASE.2021-09-02T09-21-27Z',
 				'restart' => 'unless-stopped',
 				'depends_on' => [
 					's3',
@@ -480,7 +480,7 @@ class Docker_Compose_Generator {
 	protected function get_service_tachyon() : array {
 		return [
 			'tachyon' => [
-				'image' => 'humanmade/tachyon:edge',
+				'image' => 'humanmade/tachyon:2.4.0',
 				'ports' => [
 					'8080',
 				],
@@ -513,7 +513,7 @@ class Docker_Compose_Generator {
 	protected function get_service_mailhog() : array {
 		return [
 			'mailhog' => [
-				'image' => 'cd2team/mailhog:latest',
+				'image' => 'cd2team/mailhog:1632011321',
 				'ports' => [
 					'8025',
 					'1025',
@@ -551,7 +551,7 @@ class Docker_Compose_Generator {
 					'default',
 				],
 				'restart' => 'unless-stopped',
-				'image' => 'humanmade/local-cognito:edge',
+				'image' => 'humanmade/local-cognito:1.1.0',
 				'labels' => [
 					'traefik.port=3000',
 					'traefik.protocol=http',
@@ -568,7 +568,7 @@ class Docker_Compose_Generator {
 					'default',
 				],
 				'restart' => 'unless-stopped',
-				'image' => 'humanmade/local-pinpoint:edge',
+				'image' => 'humanmade/local-pinpoint:1.3.0',
 				'labels' => [
 					'traefik.port=3000',
 					'traefik.protocol=http',
@@ -590,7 +590,7 @@ class Docker_Compose_Generator {
 	protected function get_service_xray() : array {
 		return [
 			'xray' => [
-				'image' => 'amazon/aws-xray-daemon:latest',
+				'image' => 'amazon/aws-xray-daemon:3.3.3',
 				'ports' => [
 					'2000',
 				],

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -91,7 +91,7 @@ class Docker_Compose_Generator {
 					'condition' => 'service_started',
 				],
 			],
-			'image' => 'humanmade/altis-local-server-php:4.0.0-dev',
+			'image' => 'humanmade/altis-local-server-php:edge',
 			'links' => [
 				'db:db-read-replica',
 				's3:s3.localhost',
@@ -200,7 +200,7 @@ class Docker_Compose_Generator {
 	protected function get_service_nginx() : array {
 		return [
 			'nginx' => [
-				'image' => 'humanmade/altis-local-server-nginx:3.3.0',
+				'image' => 'humanmade/altis-local-server-nginx:edge',
 				'networks' => [
 					'proxy',
 					'default',
@@ -256,7 +256,7 @@ class Docker_Compose_Generator {
 	protected function get_service_db() : array {
 		return [
 			'db' => [
-				'image' => 'mysql:5.7',
+				'image' => 'mysql/mysql-server:8.0',
 				'volumes' => [
 					'db-data:/var/lib/mysql',
 				],
@@ -416,7 +416,7 @@ class Docker_Compose_Generator {
 	protected function get_service_s3() : array {
 		return [
 			's3' => [
-				'image' => 'minio/minio:RELEASE.2020-03-19T21-49-00Z',
+				'image' => 'minio/minio:latest',
 				'volumes' => [
 					's3:/data:rw',
 				],
@@ -455,7 +455,7 @@ class Docker_Compose_Generator {
 				],
 			],
 			's3-sync-to-host' => [
-				'image' => 'minio/mc:RELEASE.2020-03-14T01-23-37Z',
+				'image' => 'minio/mc:latest',
 				'restart' => 'unless-stopped',
 				'depends_on' => [
 					's3',
@@ -480,7 +480,7 @@ class Docker_Compose_Generator {
 	protected function get_service_tachyon() : array {
 		return [
 			'tachyon' => [
-				'image' => 'humanmade/tachyon:2.3.2',
+				'image' => 'humanmade/tachyon:edge',
 				'ports' => [
 					'8080',
 				],
@@ -513,7 +513,7 @@ class Docker_Compose_Generator {
 	protected function get_service_mailhog() : array {
 		return [
 			'mailhog' => [
-				'image' => 'mailhog/mailhog:latest',
+				'image' => 'cd2team/mailhog:latest',
 				'ports' => [
 					'8025',
 					'1025',
@@ -551,7 +551,7 @@ class Docker_Compose_Generator {
 					'default',
 				],
 				'restart' => 'unless-stopped',
-				'image' => 'humanmade/local-cognito:1.0.0',
+				'image' => 'humanmade/local-cognito:edge',
 				'labels' => [
 					'traefik.port=3000',
 					'traefik.protocol=http',
@@ -568,7 +568,7 @@ class Docker_Compose_Generator {
 					'default',
 				],
 				'restart' => 'unless-stopped',
-				'image' => 'humanmade/local-pinpoint:1.2.3',
+				'image' => 'humanmade/local-pinpoint:edge',
 				'labels' => [
 					'traefik.port=3000',
 					'traefik.protocol=http',
@@ -590,7 +590,7 @@ class Docker_Compose_Generator {
 	protected function get_service_xray() : array {
 		return [
 			'xray' => [
-				'image' => 'amazon/aws-xray-daemon:3.0.1',
+				'image' => 'amazon/aws-xray-daemon:latest',
 				'ports' => [
 					'2000',
 				],

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -91,7 +91,7 @@ class Docker_Compose_Generator {
 					'condition' => 'service_started',
 				],
 			],
-			'image' => 'humanmade/altis-local-server-php:4.2.0-dev',
+			'image' => 'humanmade/altis-local-server-php:4.2.0',
 			'links' => [
 				'db:db-read-replica',
 				's3:s3.localhost',
@@ -480,7 +480,7 @@ class Docker_Compose_Generator {
 	protected function get_service_tachyon() : array {
 		return [
 			'tachyon' => [
-				'image' => 'humanmade/tachyon:2.4.0',
+				'image' => 'humanmade/tachyon:v2.4.0',
 				'ports' => [
 					'8080',
 				],


### PR DESCRIPTION
Follow up to #252

This PR was created using Altis v8 with `local-server` release candidate `8.1.0-rc` [here](https://github.com/humanmade/altis-local-server/releases/tag/8.1.0-rc)

Notes: 
- All images are native ARM64, no containers run under emulation
- All images except for Mailhog are using the original Docker base image
- Minio ~12 months ago bumped MC to v10 when multi-arch images began being built, hence the v10 config bump
- I've used `latest` for Docker images here for simplicity, pinning to specific releases would be required for release
- I'm using `mysql/mysql-server:8.0`, rather than MariaDB, solely because I have a client project where I'm using this daily, I think the suggestion has been to prefer MariaDB over MySQL v8?

### Testing

From the dashboard -> tools menu e.g. https://subdomain.altis.dev/wp-admin/tools.php
<img width="171" alt="image" src="https://user-images.githubusercontent.com/1016458/133996768-f24970e7-1b63-4a01-bd5c-8e2ddc2cad0c.png">

- ❌ S3 Browser - https://s3-subdomain.altis.dev/minio
  - The following warning is displayed when opening the above URL:
    - `NoSuchKeyThe specified key does not exist.minios3-subdomain/minious-east-xxxxxxxxxxx`
- ✅ Kibana - https://subdomain.altis.dev/kibana/
  - Works as expected and opens Kibana at https://subdomain.altis.dev/kibana/app/home#/
- ✅ Mailhog - https://subdomain.altis.dev/mailhog/
  - Works as expected and opens Mailhog at https://subdomain.altis.dev/mailhog