### PR TITLE
Always restart Elastic container unless stopped

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -311,6 +311,7 @@ class Docker_Compose_Generator {
 		return [
 			'elasticsearch' => [
 				'image' => $image,
+				'restart' => 'unless-stopped',
 				'ulimits' => [
 					'memlock' => [
 						'soft' => -1,


### PR DESCRIPTION
Elastic container can easily shutdown because of memory issues, this ensures the container is restarted if that happens to avoid distrupting the developer workflow.