### PR TITLE
[Backport v8-branch] Fix container names for Docker Compose 1.29.2

### DIFF
--- a/docker/proxy.yml
+++ b/docker/proxy.yml
@@ -4,6 +4,7 @@ services:
     networks:
       - proxy
     image: traefik:1.7
+    container_name: altis-proxy
     volumes:
       - "$PWD/conf/traefik.toml:/etc/traefik/traefik.toml"
       - "$PWD/ssl.cert:/etc/traefik/ssl.cert"

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -406,9 +406,10 @@ EOT
 			}
 		}
 
-		$container_id = exec( sprintf( 'docker ps --filter name=%s_php_1 -q', $this->get_project_subdomain() ) );
+		$container_id = exec( sprintf( 'docker ps --filter name=%s-php -q', $this->get_project_subdomain() ) );
 		if ( ! $container_id ) {
 			$output->writeln( '<error>PHP container not found to run command.</>' );
+			$output->writeln( '<info>You may need to run `composer server start` again if you have recently updated Docker.</>' );
 			return 1;
 		}
 

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -168,7 +168,12 @@ class Docker_Compose_Generator {
 	 */
 	protected function get_service_php() : array {
 		return [
-			'php' => $this->get_php_reusable(),
+			'php' => array_merge(
+				[
+					'container_name' => "{$this->project_name}-php",
+				],
+				$this->get_php_reusable()
+			),
 		];
 	}
 
@@ -181,6 +186,7 @@ class Docker_Compose_Generator {
 		return [
 			'cavalcade' => array_merge(
 				[
+					'container_name' => "{$this->project_name}-cavalcade",
 					'entrypoint' => [
 						'/usr/local/bin/cavalcade',
 					],
@@ -201,6 +207,7 @@ class Docker_Compose_Generator {
 		return [
 			'nginx' => [
 				'image' => 'humanmade/altis-local-server-nginx:3.3.0',
+				'container_name' => "{$this->project_name}-nginx",
 				'networks' => [
 					'proxy',
 					'default',
@@ -241,6 +248,7 @@ class Docker_Compose_Generator {
 		return [
 			'redis' => [
 				'image' => 'redis:3.2-alpine',
+				'container_name' => "{$this->project_name}-redis",
 				'ports' => [
 					'6379',
 				],
@@ -257,6 +265,7 @@ class Docker_Compose_Generator {
 		return [
 			'db' => [
 				'image' => 'mysql:5.7',
+				'container_name' => "{$this->project_name}-db",
 				'volumes' => [
 					'db-data:/var/lib/mysql',
 				],
@@ -298,6 +307,7 @@ class Docker_Compose_Generator {
 		return [
 			'elasticsearch' => [
 				'image' => 'humanmade/altis-local-server-elasticsearch:3.0.0',
+				'container_name' => "{$this->project_name}-es",
 				'ulimits' => [
 					'memlock' => [
 						'soft' => -1,
@@ -352,6 +362,7 @@ class Docker_Compose_Generator {
 		return [
 			'kibana' => [
 				'image' => 'blacktop/kibana:6.3',
+				'container_name' => "{$this->project_name}-kibana",
 				'networks' => [
 					'proxy',
 					'default',
@@ -386,6 +397,7 @@ class Docker_Compose_Generator {
 		return [
 			's3' => [
 				'image' => 'minio/minio:RELEASE.2020-03-19T21-49-00Z',
+				'container_name' => "{$this->project_name}-s3",
 				'volumes' => [
 					's3:/data:rw',
 				],
@@ -427,6 +439,7 @@ class Docker_Compose_Generator {
 			],
 			's3-sync-to-host' => [
 				'image' => 'minio/mc:RELEASE.2020-03-14T01-23-37Z',
+				'container_name' => "{$this->project_name}-s3-sync",
 				'restart' => 'unless-stopped',
 				'depends_on' => [
 					's3',
@@ -452,6 +465,7 @@ class Docker_Compose_Generator {
 		return [
 			'tachyon' => [
 				'image' => 'humanmade/tachyon:2.3.2',
+				'container_name' => "{$this->project_name}-tachyon",
 				'ports' => [
 					'8080',
 				],
@@ -485,6 +499,7 @@ class Docker_Compose_Generator {
 		return [
 			'mailhog' => [
 				'image' => 'mailhog/mailhog:latest',
+				'container_name' => "{$this->project_name}-mailhog",
 				'ports' => [
 					'8025',
 					'1025',
@@ -514,6 +529,7 @@ class Docker_Compose_Generator {
 	protected function get_service_analytics() : array {
 		return [
 			'cognito' => [
+				'container_name' => "{$this->project_name}-cognito",
 				'ports' => [
 					'3000',
 				],
@@ -531,6 +547,7 @@ class Docker_Compose_Generator {
 				],
 			],
 			'pinpoint' => [
+				'container_name' => "{$this->project_name}-pinpoint",
 				'ports' => [
 					'3000',
 				],
@@ -562,6 +579,7 @@ class Docker_Compose_Generator {
 		return [
 			'xray' => [
 				'image' => 'amazon/aws-xray-daemon:3.0.1',
+				'container_name' => "{$this->project_name}-xray",
 				'ports' => [
 					'2000',
 				],


### PR DESCRIPTION
Backporting #350

-----------------------

Docker Compose just shipped a new version that generates container names differently using hyphens instead of underscores. We had a hardcoded check for the name `_php_1` in the exec command which failed with the new container name scheme.

Fixes #349