### PR TITLE
[Backport v6-branch] Fix container names for Docker Compose 1.29.2

### DIFF
--- a/docker/proxy.yml
+++ b/docker/proxy.yml
@@ -4,6 +4,7 @@ services:
     networks:
       - proxy
     image: traefik:1.7
+    container_name: altis-proxy
     volumes:
       - "$PWD/conf/traefik.toml:/etc/traefik/traefik.toml"
       - "$PWD/ssl.cert:/etc/traefik/ssl.cert"

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -384,9 +384,10 @@ EOT
 			}
 		}
 
-		$container_id = exec( sprintf( 'docker ps --filter name=%s_php_1 -q', $this->get_project_subdomain() ) );
+		$container_id = exec( sprintf( 'docker ps --filter name=%s-php -q', $this->get_project_subdomain() ) );
 		if ( ! $container_id ) {
 			$output->writeln( '<error>PHP container not found to run command.</>' );
+			$output->writeln( '<info>You may need to run `composer server start` again if you have recently updated Docker.</>' );
 			return 1;
 		}
 

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -172,7 +172,12 @@ class Docker_Compose_Generator {
 	 */
 	protected function get_service_php() : array {
 		return [
-			'php' => $this->get_php_reusable(),
+			'php' => array_merge(
+				[
+					'container_name' => "{$this->project_name}-php",
+				],
+				$this->get_php_reusable()
+			),
 		];
 	}
 
@@ -185,6 +190,7 @@ class Docker_Compose_Generator {
 		return [
 			'cavalcade' => array_merge(
 				[
+					'container_name' => "{$this->project_name}-cavalcade",
 					'entrypoint' => [
 						'/usr/local/bin/cavalcade',
 					],
@@ -205,6 +211,7 @@ class Docker_Compose_Generator {
 		return [
 			'nginx' => [
 				'image' => 'humanmade/altis-local-server-nginx:3.1.0',
+				'container_name' => "{$this->project_name}-nginx",
 				'networks' => [
 					'proxy',
 					'default',
@@ -239,6 +246,7 @@ class Docker_Compose_Generator {
 		return [
 			'redis' => [
 				'image' => 'redis:3.2-alpine',
+				'container_name' => "{$this->project_name}-redis",
 				'ports' => [
 					'6379',
 				],
@@ -255,6 +263,7 @@ class Docker_Compose_Generator {
 		return [
 			'db' => [
 				'image' => 'mysql:5.7',
+				'container_name' => "{$this->project_name}-db",
 				'volumes' => [
 					'db-data:/var/lib/mysql',
 				],
@@ -296,6 +305,7 @@ class Docker_Compose_Generator {
 		return [
 			'elasticsearch' => [
 				'image' => 'humanmade/altis-local-server-elasticsearch:3.0.0',
+				'container_name' => "{$this->project_name}-es",
 				'ulimits' => [
 					'memlock' => [
 						'soft' => -1,
@@ -350,6 +360,7 @@ class Docker_Compose_Generator {
 		return [
 			'kibana' => [
 				'image' => 'blacktop/kibana:6.3',
+				'container_name' => "{$this->project_name}-kibana",
 				'networks' => [
 					'proxy',
 					'default',
@@ -384,6 +395,7 @@ class Docker_Compose_Generator {
 		return [
 			's3' => [
 				'image' => 'minio/minio:RELEASE.2020-03-19T21-49-00Z',
+				'container_name' => "{$this->project_name}-s3",
 				'volumes' => [
 					's3:/data:rw',
 				],
@@ -425,6 +437,7 @@ class Docker_Compose_Generator {
 			],
 			's3-sync-to-host' => [
 				'image' => 'minio/mc:RELEASE.2020-03-14T01-23-37Z',
+				'container_name' => "{$this->project_name}-s3-sync",
 				'restart' => 'unless-stopped',
 				'depends_on' => [
 					's3',
@@ -450,6 +463,7 @@ class Docker_Compose_Generator {
 		return [
 			'tachyon' => [
 				'image' => 'humanmade/tachyon:2.3.2',
+				'container_name' => "{$this->project_name}-tachyon",
 				'ports' => [
 					'8080',
 				],
@@ -483,6 +497,7 @@ class Docker_Compose_Generator {
 		return [
 			'mailhog' => [
 				'image' => 'mailhog/mailhog:latest',
+				'container_name' => "{$this->project_name}-mailhog",
 				'ports' => [
 					'8025',
 					'1025',
@@ -512,6 +527,7 @@ class Docker_Compose_Generator {
 	protected function get_service_analytics() : array {
 		return [
 			'cognito' => [
+				'container_name' => "{$this->project_name}-cognito",
 				'ports' => [
 					'3000',
 				],
@@ -529,6 +545,7 @@ class Docker_Compose_Generator {
 				],
 			],
 			'pinpoint' => [
+				'container_name' => "{$this->project_name}-pinpoint",
 				'ports' => [
 					'3000',
 				],
@@ -560,6 +577,7 @@ class Docker_Compose_Generator {
 		return [
 			'xray' => [
 				'image' => 'amazon/aws-xray-daemon:3.0.1',
+				'container_name' => "{$this->project_name}-xray",
 				'ports' => [
 					'2000',
 				],


### PR DESCRIPTION
Backporting #350

-----------------

Docker Compose just shipped a new version that generates container names differently using hyphens instead of underscores. We had a hardcoded check for the name `_php_1` in the exec command which failed with the new container name scheme.

Fixes #349