### PR TITLE
Fix db commands for Docker Compose v2

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -528,13 +528,12 @@ EOT
 		$columns = exec( 'tput cols' );
 		$lines = exec( 'tput lines' );
 
-		$base_command_prefix = $this->get_base_command_prefix();
-
 		$base_command = sprintf(
-			"$base_command_prefix %s exec -e COLUMNS=%d -e LINES=%d db",
-			$this->get_compose_command(),
+			// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
+			'docker exec -it -u root -e COLUMNS=%d -e LINES=%d -e MYSQL_PWD=wordpress %s-db',
 			$columns,
-			$lines
+			$lines,
+			$this->get_project_subdomain()
 		);
 
 		$return_val = 0;
@@ -591,11 +590,11 @@ EOT;
 					$query = "$query;";
 				}
 				// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
-				passthru( "$base_command mysql --database=wordpress --user=root -pwordpress -e \"$query\"", $return_val );
+				passthru( "$base_command mysql --database=wordpress --user=root -e \"$query\"", $return_val );
 				break;
 			case null:
 				// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
-				passthru( "$base_command mysql --database=wordpress --user=root -pwordpress", $return_val );
+				passthru( "$base_command mysql --database=wordpress --user=root", $return_val );
 				break;
 			default:
 				$output->writeln( "<error>The subcommand $db is not recognized</error>" );


### PR DESCRIPTION
This was less an issue with the new container and some unusual behaviour with Docker Compose v2 not properly allocating a TTY when used via `passthru` in PHP.

Switch to using `docker exec` and referencing the container name directly.

Related to QA issues from humanmade/product-dev#788

Fixes #364 