### PR TITLE
Update to use new `mutagen-compose` beta

### DIFF
--- a/docs/mutagen-file-sharing.md
+++ b/docs/mutagen-file-sharing.md
@@ -2,33 +2,37 @@
 
 [Mutagen](https://mutagen.io/) is a powerful tool for optimising file system mounts among other things (not just for Docker!).
 
-Local Server provides an experimental integration with Mutagen to improve the performance of your development environment. This is unlikely to provide much benefit if you use Linux as your operating system.
+Local Server provides an _experimental_ integration with Mutagen to improve the performance of your development environment. This is unlikely to provide much benefit if you use Linux as your operating system.
 
 ## Installation
 
-To get started you will need to [install Mutagen Beta](https://mutagen.io/documentation/introduction/installation#development-channels). The beta version has integrated `docker compose` orchestration support through the `mutagen compose` command.
+To get started you will need to [install the Mutagen Compose Beta](https://github.com/mutagen-io/mutagen-compose). The beta version has integrated `docker compose` orchestration support through the `mutagen-compose` command.
+
+In order to work you must be using Docker Compose v2, it is recommended to update Docker Desktop or Docker Engine to the latest version to get this.
 
 ### MacOS
 
 The easiest way to install Mutagen on Mac is using [HomeBrew](https://brew.sh/).
 
-- With HomeBrew: `brew install mutagen-io/mutagen/mutagen-beta`
-- [Mac - Intel build (v0.12.0-beta7)](https://github.com/mutagen-io/mutagen/releases/download/v0.12.0-beta7/mutagen_darwin_amd64_v0.12.0-beta7.tar.gz)
-- [Mac - ARM Build (v0.12.0-beta7))](https://github.com/mutagen-io/mutagen/releases/download/v0.12.0-beta7/mutagen_darwin_arm64_v0.12.0-beta7.tar.gz)
+```sh
+brew install mutagen-io/mutagen/mutagen-beta mutagen-io/mutagen/mutagen-compose-beta
+```
 
-If using the download directly open the zipped file and copy the `mutagen` file to your `/usr/local/bin` directory. The `mutagen` command should now be available in your terminal.
+For all available builds see the [releases page](https://github.com/mutagen-io/mutagen-compose/releases) for the latest release and open the assets section.
 
-### Windows
+If using the download directly open the zipped file and copy the `mutagen-compose` file to your `/usr/local/bin` directory. The `mutagen-compose` command should now be available in your terminal.
 
-- [32-bit build](https://github.com/mutagen-io/mutagen/releases/download/v0.12.0-beta7/mutagen_windows_386_v0.12.0-beta7.zip)
-- [64-bit build](https://github.com/mutagen-io/mutagen/releases/download/v0.12.0-beta7/mutagen_windows_amd64_v0.12.0-beta7.zip)
-- [ARM build](https://github.com/mutagen-io/mutagen/releases/download/v0.12.0-beta7/mutagen_windows_arm_v0.12.0-beta7.zip)
+### Other OSes
 
-Once downloaded open the zip file and run `mutagen.exe` then follow the prompts on screen.
+For all other available binaries including Windows see the [releases page](https://github.com/mutagen-io/mutagen-compose/releases) for the latest release and open the assets section.
 
-### Other Operating Systems
+For Windows once downloaded unzip file and move `mutagen-compose.exe` to somewhere referenced in your `$PATH` environment variable.
 
-For all other operating systems check the [beta release assets list for the appropriate build](https://github.com/mutagen-io/mutagen/releases/tag/v0.12.0-beta7).
+Although not recommended for Linux you may wish to use Mutagen with WSL, in which case you can use the appropriate Linux binary:
+
+- 386 for 32-Bit systems
+- AMD64 for 64-Bit systems
+- ARM or ARM64 for ARM systems
 
 ## Activating Mutagen
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -61,3 +61,13 @@ When using Windows or MacOS on projects with a lot of files such as a `node_modu
 The first thing you should try is to switch off the gRPC file sharing option if enabled in the Docker Desktop preferences. If that doesn't help improve the speed then you can try the experimental Mutagen file sharing option.
 
 See the [Mutagen file sharing set up guide for more details](./mutagen-file-sharing.md).
+
+## Server fails to start when using Mutagen
+
+Due to the variability of Docker Desktop, Docker Engine and Mutagen versions, and that Mutagen is still in beta you encounter some problems.
+
+Currently Mutagen file sharing support has the following pre-requisites in order to function:
+
+- You must be using Docker Compose v2, available with Docker Desktop 4.1.0 and up
+  - Check your Docker Desktop preferences as there is a toggle to use Compose v1
+- You must have the latest Mutagen Compose Beta installed, or at least 0.13.0-beta3

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -64,7 +64,7 @@ See the [Mutagen file sharing set up guide for more details](./mutagen-file-shar
 
 ## Server fails to start when using Mutagen
 
-Due to the variability of Docker Desktop, Docker Engine and Mutagen versions, and that Mutagen is still in beta you encounter some problems.
+Due to the variability of Docker Desktop, Docker Engine and Mutagen versions, and that Mutagen is still in beta, you may encounter some problems.
 
 Currently Mutagen file sharing support has the following pre-requisites in order to function:
 

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -782,9 +782,9 @@ EOT;
 			return $is_installed;
 		}
 		if ( self::is_linux() || self::is_macos() ) {
-			$is_installed = ! empty( shell_exec( 'which mutagen' ) );
+			$is_installed = ! empty( shell_exec( 'which mutagen-compose' ) );
 		} else {
-			$is_installed = ! empty( shell_exec( 'where mutagen' ) );
+			$is_installed = ! empty( shell_exec( 'where mutagen-compose' ) );
 		}
 		return $is_installed;
 	}
@@ -805,7 +805,7 @@ EOT;
 			$default_command = strpos( implode( "\n", $output ), 'Usage:  docker compose' ) !== false ? 'docker compose' : 'docker-compose';
 		}
 		return sprintf( '%s %s',
-			$this->is_mutagen_installed() && $mutagen ? 'mutagen compose' : $default_command,
+			$this->is_mutagen_installed() && $mutagen ? 'mutagen-compose' : $default_command,
 			$command
 		);
 	}


### PR DESCRIPTION
With Docker Compose v2 there is now a new Mutagen Compose command that works with it and promises to be much more robust. In order to function correctly users must have at least Mutagen Compose 0.13.0-beta3 and be using Docker Compose v2.