### PR TITLE
Use correct placeholder in sequel template

### DIFF
--- a/templates/sequel.xml
+++ b/templates/sequel.xml
@@ -65,7 +65,7 @@
 		<key>rdbms_type</key>
 		<string>mysql</string>
 		<key>rdbms_version</key>
-		<string><%= MYSQL_VERSION %></string>
+		<string><%= MYSQL_MAJOR %></string>
 		<key>version</key>
 		<integer>1</integer>
 	</dict>


### PR DESCRIPTION
Running the command `composer server db sequel` to open the database in Sequel Ace (or Sequel Pro) app does not work in Altis local server v9. I get the following error:

```
Error while reading connection data file
Connection data file couldn't be read. (The data couldn’t be read because it isn’t in the correct format.)
```

My suspicion is that it is caused by this line in the sequel.xml template: https://github.com/humanmade/altis-local-server/blob/9.0.2/templates/sequel.xml#L68 

This is not a placeholder returned by [`get_db_connection_data` in v9](https://github.com/humanmade/altis-local-server/blob/9.0.0/inc/composer/class-command.php#L627) ([but was in v8](https://github.com/humanmade/altis-local-server/blob/8.0.5/inc/composer/class-command.php#L653)). Looks like it was replaced with `MYSQL_MAJOR`