### PR TITLE
Add a question when a user hasn't selected a log type

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Process\Process;
 
 /**
@@ -492,7 +493,30 @@ EOT
 	 * @return int
 	 */
 	protected function logs( InputInterface $input, OutputInterface $output ) {
-		$log = $input->getArgument( 'options' )[0];
+		var_dump( 'start' );
+		if( !isset( $input->getArgument( 'options' )[0] ) ){
+			$helper = $this->getHelper( 'question' );
+			$question = new ChoiceQuestion(
+				'Please select your prefered log type (defaults to php)',
+				[
+					'php',
+					'cavalcade',
+					'db',
+					'elasticsearch',
+					'nginx',
+					'redis',
+					's3',
+					'xray',
+				],
+				0
+			);
+			$question->setErrorMessage( 'Selected log type %s is invalid, please select again!' );
+			$log_type = $helper->ask( $input, $output, $question );
+			$output->writeln( 'You have selected: '.$log_type );
+			$log = $log_type;
+		} else {
+			$log = $input->getArgument( 'options' )[0];
+		}
 		$compose = new Process( $this->get_compose_command( 'logs --tail=100 -f ' . $log ), 'vendor', $this->get_env() );
 		$compose->setTty( posix_isatty( STDOUT ) );
 		$compose->setTimeout( 0 );

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -505,7 +505,6 @@ EOT
 					'nginx',
 					'redis',
 					's3',
-					'tachyon',
 					'xray',
 				],
 				0

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -18,8 +18,8 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Process\Process;
 
 /**
@@ -493,11 +493,10 @@ EOT
 	 * @return int
 	 */
 	protected function logs( InputInterface $input, OutputInterface $output ) {
-		var_dump( 'start' );
-		if( !isset( $input->getArgument( 'options' )[0] ) ){
+		if ( ! isset ( $input->getArgument ( 'options' )[0] ) ) {
 			$helper = $this->getHelper( 'question' );
 			$question = new ChoiceQuestion(
-				'Please select your prefered service (defaults to php)',
+				'Please select a service (defaults to php)',
 				[
 					'php',
 					'cavalcade',
@@ -506,13 +505,14 @@ EOT
 					'nginx',
 					'redis',
 					's3',
+					'tachyon',
 					'xray',
 				],
 				0
 			);
-			$question->setErrorMessage( 'Selected service %s is invalid, please select again!' );
+			$question->setErrorMessage( '%s is not a recognised service, please select again!' );
 			$service = $helper->ask( $input, $output, $question );
-			$output->writeln( 'You have selected: '.$service );
+			$output->writeln( sprintf( '<comment>Fetching %s logs...</>', $service ) );
 			$log = $service;
 		} else {
 			$log = $input->getArgument( 'options' )[0];

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -493,7 +493,7 @@ EOT
 	 * @return int
 	 */
 	protected function logs( InputInterface $input, OutputInterface $output ) {
-		if ( ! isset ( $input->getArgument ( 'options' )[0] ) ) {
+		if ( ! isset( $input->getArgument( 'options' )[0] ) ) {
 			$helper = $this->getHelper( 'question' );
 			$question = new ChoiceQuestion(
 				'Please select a service (defaults to php)',

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -497,7 +497,7 @@ EOT
 		if( !isset( $input->getArgument( 'options' )[0] ) ){
 			$helper = $this->getHelper( 'question' );
 			$question = new ChoiceQuestion(
-				'Please select your prefered log type (defaults to php)',
+				'Please select your prefered service (defaults to php)',
 				[
 					'php',
 					'cavalcade',
@@ -510,10 +510,10 @@ EOT
 				],
 				0
 			);
-			$question->setErrorMessage( 'Selected log type %s is invalid, please select again!' );
-			$log_type = $helper->ask( $input, $output, $question );
-			$output->writeln( 'You have selected: '.$log_type );
-			$log = $log_type;
+			$question->setErrorMessage( 'Selected service %s is invalid, please select again!' );
+			$service = $helper->ask( $input, $output, $question );
+			$output->writeln( 'You have selected: '.$service );
+			$log = $service;
 		} else {
 			$log = $input->getArgument( 'options' )[0];
 		}


### PR DESCRIPTION
When a user requests logs with `composer server logs` and doesn't pass a service they are presented with an error that isn't clear.

The user will now be presented with options of the different services that they can select from. The default service will be `php` and the remaining options are presented in alphabetical order.

Fixes https://github.com/humanmade/altis-local-server/issues/216