### PR TITLE
Ensure to disable pseudo-tty when get db info

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -667,7 +667,7 @@ EOT;
 		$lines = exec( 'tput lines' );
 
 		$base_command = sprintf(
-			"$command_prefix %s exec -e COLUMNS=%d -e LINES=%d db",
+			"$command_prefix %s exec -e COLUMNS=%d -e LINES=%d -T db",
 			$this->get_compose_command(),
 			$columns,
 			$lines


### PR DESCRIPTION
Without `-T`:
```
❯ composer server db info

[detail truncated]

[ErrorException]
  Undefined index: MYSQL_ROOT_PASSWORD
```

With `-T`:
```
❯ composer server db info
Root password:  [truncated]

Database:       [truncated]
User:           [truncated]
Password:       [truncated]

Host:           0.0.0.0
Port:           58388

Version:        5.7.35-1debian10
```

I'm currently on Altis v6 but i see this might be reproduce-able on v9.