### PR TITLE
Support mounting tmp directory and using webgrind for profiling

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,7 @@ The subdomain used for the project can be configured via the `modules.local-serv
   * `--mutagen` will enable Mutagen for container file sharing.
 * `composer server stop [<service>] [--clean]` - Stops the containers or specified service.
   * `--clean` will also stop the proxy container if no service is specified, only use this if you have no other instances of Local Server
+  * `--tmp` will mount the PHP container's `/tmp` directory to `.tmp` in your project root. This is useful for debugging with `--xdebug=profile` as the cachegrind files are easily available
 * `composer server restart [<service>]` - Restart a given container, or all containers if none is provided. Available values are `nginx`, `php`, `db`, `redis`, `cavalcade`, `tachyon`, `s3` and `elasticsearch`.
 * `composer server destroy [--clean]` - Stops and destroys all containers.
   * `--clean` will also destroy the proxy container, only use this if you have no other instances of Local Server

--- a/docs/using-xdebug.md
+++ b/docs/using-xdebug.md
@@ -134,3 +134,27 @@ Local Server takes advantage of PHPStorm's [Zero Configuration Debugging](https:
    ![Example PHPStorm Configuration](./assets/phpstorm-config.png)
 3. Set some breakpoints and click the "Listen for Debug Connections" icon<br />
    ![PHPStorm Debug Icon](./assets/phpstorm-start-debug.png)
+
+
+## Accessing Xdebug output
+
+If you are starting Xdebug with any the following modes you will want to access their output in the PHP container's `/tmp` directory.
+
+This is achievable in 2 ways:
+
+1. Use `composer server shell` to access the container and look at the files using `cat`, `less` or other file reader
+2. Pass the `--tmp` flag when starting Local Server to mount the `/tmp` directory to `.tmp` in your project root
+
+The second option using `--tmp` has the advantage of allowing you to easily open the output files in external programs that understand them such as [KCacheGrind](https://kcachegrind.github.io/).
+
+Note that you should add `.tmp` to your project's `.gitignore` file if you use this option.
+
+## Profiling With WebGrind
+
+In most cases the XRay traces in the Query Monitor Dev Tools will give a good indication of any bottlenecks in your code however those traces are not available when running CLI commands or background cron tasks.
+
+If Xdebug is activated in profiling mode using `--xdebug=profile` on start up it will generate cachegrind files in the `/tmp` directory.
+
+You can use the `--tmp` option to mount and view these files in a program like KCacheGrind or QCacheGrind however Local Server provides a web interface for viewing the profiles. This is set up automatically if starting the server with `--xdebug=profile`.
+
+In your browser go to `/webgrind/` on your project domain, for example `https://my-project.altis.dev/webgrind/` to access the UI for viewing

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -48,11 +48,13 @@ class Command extends BaseCommand {
 Run the local development server.
 
 Default command - start the local development server:
-	start [--xdebug=<mode>] [--mutagen]
-	                              Passing --xdebug starts the server with xdebug enabled
+	start [--xdebug=<mode>] [--mutagen] [--tmp]
+	                              --xdebug starts the server with xdebug enabled
 	                              optionally set the xdebug mode by assigning a value.
-	                              Passing --mutagen will start the server using Mutagen
+	                              --mutagen will start the server using Mutagen
 	                              for file sharing.
+	                              --tmp will mount the PHP container's /tmp directory to
+	                              .tmp in your project directory. Useful with --xdebug=profile
 Stop the local development server or specific service:
 	stop [<service>] [--clean]                passing --clean will also stop the proxy container
 Restart the local development server:
@@ -80,7 +82,8 @@ EOT
 			)
 			->addOption( 'xdebug', null, InputOption::VALUE_OPTIONAL, 'Start the server with Xdebug', 'debug' )
 			->addOption( 'mutagen', null, InputOption::VALUE_NONE, 'Start the server with Mutagen file sharing' )
-			->addOption( 'clean', null, InputOption::VALUE_NONE, 'Remove or stop the proxy container when destroying or stopping the server' );
+			->addOption( 'clean', null, InputOption::VALUE_NONE, 'Remove or stop the proxy container when destroying or stopping the server' )
+			->addOption( 'tmp', null, InputOption::VALUE_NONE, 'Mount the PHP container\'s /tmp directory to `.tmp` for debugging purposes' );
 	}
 
 	/**
@@ -120,11 +123,17 @@ EOT
 		$settings = [
 			'xdebug' => 'off',
 			'mutagen' => 'off',
+			'tmp' => false,
 		];
 
 		// If Xdebug switch is passed add to docker compose args.
 		if ( $input->hasParameterOption( '--xdebug' ) ) {
 			$settings['xdebug'] = $input->getOption( 'xdebug' );
+		}
+
+		// If tmp switch is passed add to docker compose args.
+		if ( $input->hasParameterOption( '--tmp' ) ) {
+			$settings['tmp'] = true;
 		}
 
 		// Use mutagen if available.

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -107,6 +107,7 @@ class Docker_Compose_Generator {
 				$this->get_app_volume(),
 				"{$this->config_dir}/php.ini:/usr/local/etc/php/conf.d/altis.ini",
 				'socket:/var/run/php-fpm',
+				'tmp:/tmp',
 			],
 			'networks' => [
 				'proxy',
@@ -168,7 +169,7 @@ class Docker_Compose_Generator {
 	 * @return array
 	 */
 	protected function get_service_php() : array {
-		$config = [
+		return [
 			'php' => array_merge(
 				[
 					'container_name' => "{$this->project_name}-php",
@@ -176,8 +177,42 @@ class Docker_Compose_Generator {
 				$this->get_php_reusable()
 			),
 		];
-		$config['php']['volumes'][] = "{$this->root_dir}/.tmp:/tmp";
-		return $config;
+	}
+
+	/**
+	 * Webgrind service container for viewing Xdebug profiles.
+	 *
+	 * @return array
+	 */
+	protected function get_service_webgrind() : array {
+		return [
+			'webgrind' => [
+				'container_name' => "{$this->project_name}-webgrind",
+				'image' => 'wodby/webgrind:1.9',
+				'networks' => [
+					'proxy',
+					'default',
+				],
+				'depends_on' => [
+					'php',
+				],
+				'ports' => [
+					'8080',
+				],
+				'volumes' => [
+					'tmp:/tmp',
+				],
+				'labels' => [
+					'traefik.port=8080',
+					'traefik.protocol=http',
+					'traefik.docker.network=proxy',
+					"traefik.frontend.rule=Host:{$this->hostname};PathPrefix:/webgrind;PathPrefixStrip:/webgrind",
+				],
+				'environment' => [
+					'WEBGRIND_DEFAULT_TIMEZONE' => 'UTC',
+				],
+			],
+		];
 	}
 
 	/**
@@ -673,6 +708,10 @@ class Docker_Compose_Generator {
 			$services = array_merge( $services, $this->get_service_kibana() );
 		}
 
+		if ( strpos( $this->args['xdebug'] ?? false, 'profile' ) !== false ) {
+			$services = array_merge( $services, $this->get_service_webgrind() );
+		}
+
 		// Default compose configuration.
 		$config = [
 			'version' => '2.3',
@@ -692,6 +731,17 @@ class Docker_Compose_Generator {
 				'socket' => null,
 			],
 		];
+
+		// Mount tmp volume locally if requested.
+		if ( $this->args['tmp'] ?? false ) {
+			$config['volumes']['tmp'] = [
+				'driver' => 'local',
+				'driver_opts' => [
+					'device' => "{$this->root_dir}/.tmp",
+					'o' => 'bind',
+				],
+			];
+		}
 
 		// Handle mutagen volume according to args.
 		if ( ! empty( $this->args['mutagen'] ) && $this->args['mutagen'] === 'on' ) {

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -168,7 +168,7 @@ class Docker_Compose_Generator {
 	 * @return array
 	 */
 	protected function get_service_php() : array {
-		return [
+		$config = [
 			'php' => array_merge(
 				[
 					'container_name' => "{$this->project_name}-php",
@@ -176,6 +176,8 @@ class Docker_Compose_Generator {
 				$this->get_php_reusable()
 			),
 		];
+		$config['php']['volumes'][] = "{$this->root_dir}/.tmp:/tmp";
+		return $config;
 	}
 
 	/**


### PR DESCRIPTION
Xdebug generates output files in the `/tmp` directory that can be read by KCacheGrind, QCacheGrind and WebGrind for profiling. This covers the bases that XHProf misses as it can be used to profile Cavalcade and CLI invocations.

This also uses the as yet unused `tmp` volume and shares it between the PHP containers meaning `composer server logs php` provides a combined error log from both cavalcade and PHP.

Lastly to support other Xdebug related output and `/tmp` related debugging the `--tmp` option will mount the `/tmp` directory to `.tmp` in the project root in order to provide easy access to files.