### PR TITLE
Allow ssh as an alias for shell

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -39,7 +39,7 @@ class Command extends BaseCommand {
 			->setName( 'server' )
 			->setDescription( 'Altis Local Server' )
 			->setDefinition( [
-				new InputArgument( 'subcommand', null, 'start, stop, restart, cli, exec, shell, status, db, set, logs.' ),
+				new InputArgument( 'subcommand', null, 'start, stop, restart, cli, exec, shell, ssh, status, db, set, logs.' ),
 				new InputArgument( 'options', InputArgument::IS_ARRAY ),
 			] )
 			->setAliases( [ 'local-server' ] )
@@ -168,7 +168,7 @@ EOT
 			return $this->status( $input, $output );
 		} elseif ( $subcommand === 'logs' ) {
 			return $this->logs( $input, $output );
-		} elseif ( $subcommand === 'shell' ) {
+		} elseif ( in_array( $subcommand, [ 'shell', 'ssh' ], true ) ) {
 			return $this->shell( $input, $output );
 		} elseif ( $subcommand === 'import-uploads' ) {
 			return $this->import_uploads( $input, $output );


### PR DESCRIPTION
This will save a massive amount of frustration and anger towards this package by allowing muscle memory from 10 years of vagrant to work, rather than continuously pressing backspace and retyping ssh as shell. It will also significantly cut down on the number of `--help` commands issued.

Packages should make engineers happy, not angry.