### PR TITLE
Fix symfony console version to 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
 	"require": {
 		"php": ">=7.1",
 		"composer-plugin-api": "^1.1 || ^2.0",
-		"symfony/yaml": "~5.4.3"
+		"symfony/yaml": "~5.4.3",
+		"symfony/console": "^5.4.1"
 	},
 	"extra": {
 		"class": "Altis\\Local_Server\\Composer\\Plugin",


### PR DESCRIPTION
Composer 2.3 allows for Symfony console v6 which has a breaking change for the `Process` object. This fixes the version to one that composer 2.3 allows but is still compatible with Altis.