### PR TITLE
Add support for Composer 2.3 version of Symfony Console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
 	"require": {
 		"php": ">=7.1",
 		"composer-plugin-api": "^1.1 || ^2.0",
-		"symfony/yaml": "~5.4.3",
-		"symfony/console": "^5.4.1"
+		"symfony/yaml": "~5.4.3"
 	},
 	"extra": {
 		"class": "Altis\\Local_Server\\Composer\\Plugin",

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -208,7 +208,7 @@ EOT
 	protected function start( InputInterface $input, OutputInterface $output ) {
 		$output->writeln( '<info>Starting...</>' );
 
-		$proxy = new Process( $this->get_compose_command( '-f proxy.yml up -d' ), 'vendor/altis/local-server/docker' );
+		$proxy = $this->process( $this->get_compose_command( '-f proxy.yml up -d' ), 'vendor/altis/local-server/docker' );
 		$proxy->setTimeout( 0 );
 		$proxy->setTty( posix_isatty( STDOUT ) );
 		$proxy_failed = $proxy->run( function ( $type, $buffer ) {
@@ -222,7 +222,7 @@ EOT
 
 		$env = $this->get_env();
 
-		$compose = new Process( $this->get_compose_command( 'up -d --remove-orphans', true ), 'vendor', $env );
+		$compose = $this->process( $this->get_compose_command( 'up -d --remove-orphans', true ), 'vendor', $env );
 		$compose->setTty( posix_isatty( STDOUT ) );
 		$compose->setTimeout( 0 );
 		$failed = $compose->run( function ( $type, $buffer ) {
@@ -277,6 +277,7 @@ EOT
 		$output->writeln( '<info>Startup completed.</>' );
 		$output->writeln( '<info>To access your site visit:</> <comment>' . $site_url . '</>' );
 
+		return 0;
 	}
 
 	/**
@@ -296,7 +297,7 @@ EOT
 			$service = '';
 		}
 
-		$compose = new Process( $this->get_compose_command( "stop $service", true ), 'vendor', $this->get_env() );
+		$compose = $this->process( $this->get_compose_command( "stop $service", true ), 'vendor', $this->get_env() );
 		$compose->setTimeout( 0 );
 		$compose->setTty( posix_isatty( STDOUT ) );
 		$return_val = $compose->run( function ( $type, $buffer ) {
@@ -305,7 +306,7 @@ EOT
 
 		if ( $service === '' && $input->hasParameterOption( '--clean' ) ) {
 			$output->writeln( '<info>Stopping proxy container...</>' );
-			$proxy = new Process( $this->get_compose_command( '-f proxy.yml stop' ), 'vendor/altis/local-server/docker' );
+			$proxy = $this->process( $this->get_compose_command( '-f proxy.yml stop' ), 'vendor/altis/local-server/docker' );
 			$proxy->setTimeout( 0 );
 			$proxy->setTty( posix_isatty( STDOUT ) );
 			$proxy->run( function ( $type, $buffer ) {
@@ -338,7 +339,7 @@ EOT
 
 		$output->writeln( '<error>Destroying...</>' );
 
-		$compose = new Process( $this->get_compose_command( 'down -v --remove-orphans', true ), 'vendor', $this->get_env() );
+		$compose = $this->process( $this->get_compose_command( 'down -v --remove-orphans', true ), 'vendor', $this->get_env() );
 		$compose->setTty( posix_isatty( STDOUT ) );
 		$return_val = $compose->run( function ( $type, $buffer ) {
 			echo $buffer;
@@ -355,7 +356,7 @@ EOT
 
 		if ( $remove_proxy ) {
 			$output->writeln( '<error>Destroying proxy container...</>' );
-			$proxy = new Process( $this->get_compose_command( '-f proxy.yml down -v' ), 'vendor/altis/local-server/docker' );
+			$proxy = $this->process( $this->get_compose_command( '-f proxy.yml down -v' ), 'vendor/altis/local-server/docker' );
 			$proxy->setTty( posix_isatty( STDOUT ) );
 			$proxy->run( function ( $type, $buffer ) {
 				echo $buffer;
@@ -381,7 +382,7 @@ EOT
 	protected function restart( InputInterface $input, OutputInterface $output ) {
 		$output->writeln( '<info>Restarting...</>' );
 
-		$proxy = new Process( $this->get_compose_command( '-f proxy.yml restart' ), 'vendor/altis/local-server/docker' );
+		$proxy = $this->process( $this->get_compose_command( '-f proxy.yml restart' ), 'vendor/altis/local-server/docker' );
 		$proxy->setTty( posix_isatty( STDOUT ) );
 		$proxy->run( function ( $type, $buffer ) {
 			echo $buffer;
@@ -393,7 +394,7 @@ EOT
 		} else {
 			$service = '';
 		}
-		$compose = new Process( $this->get_compose_command( "restart $service", true ), 'vendor', $this->get_env() );
+		$compose = $this->process( $this->get_compose_command( "restart $service", true ), 'vendor', $this->get_env() );
 		$compose->setTty( posix_isatty( STDOUT ) );
 		$return_val = $compose->run( function ( $type, $buffer ) {
 			echo $buffer;
@@ -487,7 +488,7 @@ EOT
 	 * @return int
 	 */
 	protected function status( InputInterface $input, OutputInterface $output ) {
-		$compose = new Process( $this->get_compose_command( 'ps' ), 'vendor', $this->get_env() );
+		$compose = $this->process( $this->get_compose_command( 'ps' ), 'vendor', $this->get_env() );
 		$compose->setTty( posix_isatty( STDOUT ) );
 		return $compose->run( function ( $type, $buffer ) {
 			echo $buffer;
@@ -525,7 +526,7 @@ EOT
 		} else {
 			$log = $input->getArgument( 'options' )[0];
 		}
-		$compose = new Process( $this->get_compose_command( 'logs --tail=100 -f ' . $log ), 'vendor', $this->get_env() );
+		$compose = $this->process( $this->get_compose_command( 'logs --tail=100 -f ' . $log ), 'vendor', $this->get_env() );
 		$compose->setTty( posix_isatty( STDOUT ) );
 		$compose->setTimeout( 0 );
 		return $compose->run( function ( $type, $buffer ) {
@@ -779,6 +780,42 @@ EOT;
 		}
 
 		return preg_replace( '/[^A-Za-z0-9\-\_]/', '', $project_name );
+	}
+
+	/**
+	 * Run a prepared process command for various versions of Symfony Console.
+	 *
+	 * Console v5+ requires an array for the command.
+	 * Console v1-3 only supports strings.
+	 *
+	 * @param mixed ...$args Args to pass to Process.
+	 * @return Process
+	 */
+	protected function process( ...$args ) : Process {
+		if ( version_compare( $this->get_composer_version(), '2.3', '>=' ) && ! is_array( $args[0] ) ) {
+			$args[0] = explode( ' ', $args[0] );
+		}
+
+		return new Process( ...$args );
+	}
+
+	/**
+	 * Get the composer executable version.
+	 *
+	 * @return string|null
+	 */
+	protected function get_composer_version() : ?string {
+		static $version;
+
+		if ( $version ) {
+			return $version;
+		}
+
+		preg_match( '/^Composer ([\d\.-]+)/', exec( 'composer --version' ), $composer_version );
+
+		$version = $composer_version[1] ?? null;
+
+		return $version;
 	}
 
 	/**

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -12,8 +12,8 @@
 
 namespace Altis\Local_Server\Composer;
 
-use Composer\Composer;
 use Composer\Command\BaseCommand;
+use Composer\Composer;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -12,6 +12,7 @@
 
 namespace Altis\Local_Server\Composer;
 
+use Composer\Composer;
 use Composer\Command\BaseCommand;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
@@ -792,30 +793,11 @@ EOT;
 	 * @return Process
 	 */
 	protected function process( ...$args ) : Process {
-		if ( version_compare( $this->get_composer_version(), '2.3', '>=' ) && ! is_array( $args[0] ) ) {
+		if ( version_compare( Composer::getVersion(), '2.3', '>=' ) && ! is_array( $args[0] ) ) {
 			$args[0] = explode( ' ', $args[0] );
 		}
 
 		return new Process( ...$args );
-	}
-
-	/**
-	 * Get the composer executable version.
-	 *
-	 * @return string|null
-	 */
-	protected function get_composer_version() : ?string {
-		static $version;
-
-		if ( $version ) {
-			return $version;
-		}
-
-		preg_match( '/^Composer ([\d\.-]+)/', exec( 'composer --version' ), $composer_version );
-
-		$version = $composer_version[1] ?? null;
-
-		return $version;
 	}
 
 	/**


### PR DESCRIPTION
Composer 2.3 updates `symfony/console` to 5.4 which requires an array for the first argument. This checks the version and uses a proxy function to support whichever version is running.

I tried finding a few ways to properly find the installed version of `symfony/console` with composer itself but it's not straightforward at all. Additionally if you install `symfony/console` as a dependency of this package Composer doesn't use it so we have to rely on the composer version to know which symfony packages are in use.