### PR TITLE
Remove empty parameters for `Process`

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -795,6 +795,7 @@ EOT;
 	protected function process( ...$args ) : Process {
 		if ( version_compare( Composer::getVersion(), '2.3', '>=' ) && ! is_array( $args[0] ) ) {
 			$args[0] = explode( ' ', $args[0] );
+			$args[0] = array_filter( $args[0] );
 		}
 
 		return new Process( ...$args );


### PR DESCRIPTION
Corrects issues with stopping the server while using Composer 2.3