### PR TITLE
Ensure xdebug default value is used when running Composer 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,8 @@ script:
   - cd $HOME/test-root && composer server status
   - cd $HOME/test-root && composer server exec -- ls -al
   - cd $HOME/test-root && composer server cli site list
+  - cd $HOME/test-root && composer server start --xdebug=debug,profile
+  - cd $HOME/test-root && composer server exec printenv | grep XDEBUG_MODE=debug,profile
+  - curl -XGET https://test-root.altis.dev/webgrind/ | grep '<title>webgrind</title>'
   - cd $HOME/test-root && composer server stop --clean
   - cd $HOME/test-root && composer server destroy --clean

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -129,7 +129,7 @@ EOT
 
 		// If Xdebug switch is passed add to docker compose args.
 		if ( $input->hasParameterOption( '--xdebug' ) ) {
-			$settings['xdebug'] = $input->getOption( 'xdebug' );
+			$settings['xdebug'] = $input->getOption( 'xdebug' ) ?? 'debug';
 		}
 
 		// If tmp switch is passed add to docker compose args.


### PR DESCRIPTION
The latest version of Composer uses Symfony Console 5.4.5 which seems to no longer return the default value when using `$input->getOption()` with an optional value.

This ensures the right fallback value is returned so that xdebug can be used.