### PR TITLE
[Backport v10-branch] Ensure xdebug default value is used when running Composer 2.3

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -125,7 +125,7 @@ EOT
 
 		// If Xdebug switch is passed add to docker compose args.
 		if ( $input->hasParameterOption( '--xdebug' ) ) {
-			$settings['xdebug'] = $input->getOption( 'xdebug' );
+			$settings['xdebug'] = $input->getOption( 'xdebug' ) ?? 'debug';
 		}
 
 		// Use mutagen if available.


### PR DESCRIPTION
Backporting #467

---------------------------------------

The latest version of Composer uses Symfony Console 5.4.5 which seems to no longer return the default value when using `$input->getOption()` with an optional value.

This ensures the right fallback value is returned so that xdebug can be used.