### PR TITLE
Automatically install mkcert if not yet available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ before_script:
   - cd $HOME/test-root && composer require -W "$ALTIS_PACKAGE:dev-${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} as `jq \".\\\"packages-dev\\\"[] | select (.name==\\\"$ALTIS_PACKAGE\\\") | .version\" composer.lock | sed -e 's/\"//g;/^dev/q;s/\$/9/'`"
 
 script:
-  - cd $HOME/test-root && composer server ssl install
   - cd $HOME/test-root && composer server start
   - cd $HOME/test-root && composer server db info
   - cd $HOME/test-root && composer server db exec -- "select * from wp_site;"

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -722,7 +722,9 @@ EOT;
 				],
 			] ), $output );
 
-			if ( $not_installed ) {
+			$mkcert = $this->get_mkcert_binary();
+
+			if ( $not_installed || ! $mkcert ) {
 				$output->writeln( "<error>mkcert could not be installed automatically, trying running 'composer server ssl install' manually to install and set it up.</error>" );
 				return $not_installed;
 			}

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -235,7 +235,7 @@ EOT
 		// Generate SSL certificate if not found.
 		if ( ! file_exists( 'vendor/ssl-cert.pem' ) ) {
 			// Create the certificate programmatically.
-			$generated = $this->getApplication()->find( 'local-server' )->run( new ArrayInput( [
+			$not_generated = $this->getApplication()->find( 'local-server' )->run( new ArrayInput( [
 				'subcommand' => 'ssl',
 				'options' => [
 					'generate',
@@ -243,8 +243,8 @@ EOT
 				],
 			] ), $output );
 
-			if ( $generated ) {
-				return 1;
+			if ( $not_generated ) {
+				return $not_generated;
 			}
 		}
 
@@ -714,8 +714,18 @@ EOT;
 		$mkcert = $this->get_mkcert_binary();
 
 		if ( $subcommand !== 'install' && ! $mkcert ) {
-			$output->writeln( "<error>mkcert is not installed, run 'composer server ssl install' to install and set it up.</error>" );
-			return 1;
+			// Install mkcert programmatically if not yet available.
+			$not_installed = $this->getApplication()->find( 'local-server' )->run( new ArrayInput( [
+				'subcommand' => 'ssl',
+				'options' => [
+					'install',
+				],
+			] ), $output );
+
+			if ( $not_installed ) {
+				$output->writeln( "<error>mkcert could not be installed automatically, trying running 'composer server ssl install' manually to install and set it up.</error>" );
+				return $not_installed;
+			}
 		}
 
 		switch ( $subcommand ) {


### PR DESCRIPTION
Should allow travis runs to continue as before. I noticed because the module.yml in dev tools was missing the `composer server ssl install` step that all the tests started failing.

This might resolve the output Mike saw here https://github.com/humanmade/product-dev/issues/1039