### PR TITLE
Ensure server start works with an existing install of mkcert

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -724,7 +724,7 @@ EOT;
 
 			$mkcert = $this->get_mkcert_binary();
 
-			if ( $not_installed || ! $mkcert ) {
+			if ( $not_installed && ! $mkcert ) {
 				$output->writeln( "<error>mkcert could not be installed automatically, trying running 'composer server ssl install' manually to install and set it up.</error>" );
 				return $not_installed;
 			}
@@ -754,7 +754,7 @@ EOT;
 
 				// If couldn't detect a support architecture, ask the user to install mkcert manually.
 				if ( ! $binary_arch ) {
-					$output->writeln( '<error>This command is only supported on macOS, Linux, and Windows x64, install `mkcert` manually for other systems.</error>' );
+					$output->writeln( '<error>`composer server ssl install` is only supported on macOS, Linux, and Windows x64, install `mkcert` manually for other systems.</error>' );
 					$output->writeln( '<error>Download and setup `mkcert` from https://github.com/FiloSottile/mkcert </error>' );
 					return 1;
 				}

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -763,17 +763,17 @@ EOT;
 				$mkcert = 'vendor/mkcert';
 
 				// Check if mkcert is installed globally already, bail if so.
-				$version = trim( shell_exec( 'mkcert -version' ) );
+				$version = trim( shell_exec( 'mkcert -version' ) ?: '' );
 				if ( $version ) {
-					$output->writeln( "<error>mkcert $version is installed globally already</error>" );
-					return 1;
+					$output->writeln( "<info>mkcert $version is already installed globally</>" );
+					return 0;
 				}
 
 				// Check if mkcert is installed locally already, bail if so.
-				$version = trim( shell_exec( "$mkcert -version" ) );
+				$version = trim( shell_exec( "$mkcert -version" ) ?: '' );
 				if ( $version ) {
-					$output->writeln( "<error>mkcert $version is installed locally already</error>" );
-					return 1;
+					$output->writeln( "<info>mkcert $version is already installed to vendor/mkcert</>" );
+					return 0;
 				}
 
 				$output->writeln( "Detected system architecture to be $os $arch" );
@@ -857,7 +857,7 @@ EOT;
 				break;
 
 			case 'exec':
-				$command = $input->getArgument( 'options' )[1] ?? null;
+				$command = $input->getArgument( 'options' )[1] ?? '';
 				exec( "$mkcert $command", $exec_output, $result );
 
 				if ( $result ) {


### PR DESCRIPTION
Changes the return code to zero to allow execution to proceed. `mkcert` already being available doesnt need to count as a failure for `composer server sll install`.