### PR TITLE
Switch to latest tag for mailhog

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -604,7 +604,7 @@ class Docker_Compose_Generator {
 	protected function get_service_mailhog() : array {
 		return [
 			'mailhog' => [
-				'image' => 'cd2team/mailhog:1632011321',
+				'image' => 'cd2team/mailhog:latest',
 				'container_name' => "{$this->project_name}-mailhog",
 				'ports' => [
 					'8025',


### PR DESCRIPTION
The currently pinned tag has been removed from docker hub so builds are failing