### PR TITLE
Manually load altis/core in Composer plugin

### DIFF
--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -26,6 +26,17 @@ class Plugin implements PluginInterface, Capable {
 	 * @return void
 	 */
 	public function activate( Composer $composer, IOInterface $io ) {
+		if ( ! function_exists( '\\Altis\\get_config' ) ) {
+			// Composer <2.2 has broken autoloading, so we need to manually
+			// load altis/core in.
+			$vendor_altis = dirname( __DIR__, 3 );
+			$path = $vendor_altis . '/core/inc/namespace.php';
+			if ( file_exists( $path ) ) {
+				require $path;
+			} else {
+				trigger_error( 'Altis\\get_config() not found, and cannot manually load altis/core module. See https://github.com/humanmade/altis-local-server/issues/501', E_USER_WARNING );
+			}
+		}
 	}
 
 	/**

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -29,8 +29,7 @@ class Plugin implements PluginInterface, Capable {
 		if ( ! function_exists( '\\Altis\\get_config' ) ) {
 			// Composer <2.2 has broken autoloading, so we need to manually
 			// load altis/core in.
-			$vendor_altis = dirname( __DIR__, 3 );
-			$path = $vendor_altis . '/core/inc/namespace.php';
+			$path = $composer->getConfig()->get( 'vendor-dir' ) . '/altis/core/inc/namespace.php';
 			if ( file_exists( $path ) ) {
 				require $path;
 			} else {


### PR DESCRIPTION
Fixes #501.

Using Composer 2.1.9 locally, confirmed this fixes the command for me.