### PR TITLE
Update the PHP 8.0 Docker image to 5.0.0

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -90,7 +90,7 @@ class Docker_Compose_Generator {
 	 */
 	protected function get_php_reusable() : array {
 		$version_map = [
-			'8.0' => 'humanmade/altis-local-server-php:5.0.0-beta.1',
+			'8.0' => 'humanmade/altis-local-server-php:5.0.0',
 			'7.4' => 'humanmade/altis-local-server-php:4.2.0',
 		];
 


### PR DESCRIPTION
Includes a `sendmail` binary that was accidentally lost during the move from Alpine to Debian.