### PR TITLE
Update mkcert to 1.4.4

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -736,7 +736,7 @@ EOT;
 				// Detect platform architecture to attempt automatic installation.
 				$os = php_uname( 's' ); // 'Darwin', 'Linux', 'Windows'
 				$arch = php_uname( 'm' ); // 'arm64' for arm, 'x86_64' or 'amd64' for x64
-				$mkcert_version = 'v1.4.3';
+				$mkcert_version = 'v1.4.4';
 
 				switch ( $os ) {
 					case 'Darwin':


### PR DESCRIPTION
Version 1.4.4 ships for darwin-arm64 and windows-arm64, also with better support for the snap-based Firefox in 22.04. This should remove the need to install mkcert from Brew or elsewhere on ARM-based Macs.

```
$ vendor/mkcert --version
v1.4.4
```