### PR TITLE
Route e-mails to MailHog via PHPMailer

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -172,7 +172,7 @@ class Docker_Compose_Generator {
 				'S3_UPLOADS_REGION' => 'us-east-1',
 				'S3_CONSOLE_URL' => Command::set_url_scheme( "https://s3-console-{$this->hostname}" ),
 				'TACHYON_URL' => Command::set_url_scheme( "{$this->url}tachyon" ),
-				'PHP_SENDMAIL_PATH' => '/usr/sbin/sendmail -t -i -S mailhog:1025',
+				'PHP_SENDMAIL_PATH' => '/bin/false',
 				'ALTIS_ANALYTICS_PINPOINT_ENDPOINT' => Command::set_url_scheme( "https://pinpoint-{$this->hostname}" ),
 				'ALTIS_ANALYTICS_COGNITO_ENDPOINT' => Command::set_url_scheme( "https://cognito-{$this->hostname}" ),
 				// Enables XDebug for all processes and allows setting remote_host externally for Linux support.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -237,8 +237,10 @@ function get_config_domains( bool $include_aux_services = false ) : array {
  * @param PHPMailer $phpmailer The WordPress PHPMailer instance.
  */
 function mailhog_init( $phpmailer ) {
+	// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	$phpmailer->isSMTP();
-	$phpmailer->Host     = 'mailhog'; // @phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-	$phpmailer->SMTPAuth = false; // @phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-	$phpmailer->Port     = 1025; // @phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	$phpmailer->Host     = 'mailhog'; 
+	$phpmailer->SMTPAuth = false;
+	$phpmailer->Port     = 1025;
+	// phpcs:enable
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -104,7 +104,7 @@ function bootstrap() {
 	// Disable HTTPS validation for local URLs.
 	add_filter( 'https_ssl_verify', __NAMESPACE__ . '\\disable_self_ssl_verification', 10, 2 );
 
-	// Route e-mails to MailHog
+	// Route e-mails to MailHog.
 	add_action( 'phpmailer_init', __NAMESPACE__ . '\\mailhog_init' );
 }
 
@@ -234,11 +234,11 @@ function get_config_domains( bool $include_aux_services = false ) : array {
 /**
  * Configure phpMailer to use MailHog with Local Server.
  *
- * @param PHPMailer $phpmailer
+ * @param PHPMailer $phpmailer The WordPress PHPMailer instance.
  */
 function mailhog_init( $phpmailer ) {
 	$phpmailer->isSMTP();
-	$phpmailer->Host = 'mailhog';
-	$phpmailer->SMTPAuth = false;
-	$phpmailer->Port = 1025;
+	$phpmailer->Host     = 'mailhog'; // @phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	$phpmailer->SMTPAuth = false; // @phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	$phpmailer->Port     = 1025; // @phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -103,6 +103,9 @@ function bootstrap() {
 
 	// Disable HTTPS validation for local URLs.
 	add_filter( 'https_ssl_verify', __NAMESPACE__ . '\\disable_self_ssl_verification', 10, 2 );
+
+	// Route e-mails to MailHog
+	add_action( 'phpmailer_init', __NAMESPACE__ . '\\mailhog_init' );
 }
 
 /**
@@ -226,4 +229,16 @@ function get_config_domains( bool $include_aux_services = false ) : array {
 	}
 
 	return $domains;
+}
+
+/**
+ * Configure phpMailer to use MailHog with Local Server.
+ *
+ * @param PHPMailer $phpmailer
+ */
+function mailhog_init( $phpmailer ) {
+	$phpmailer->isSMTP();
+	$phpmailer->Host = 'mailhog';
+	$phpmailer->SMTPAuth = false;
+	$phpmailer->Port = 1025;
 }


### PR DESCRIPTION
Instead of relying on sendmail to do the work, set PHPMailer to speak SMTP directly to the MailHog service. This removes the sendmail dependency, and resolves line-endings inconsistencies between PHP 7.4 and 8.0.

Sending e-mails directly through `mail()` will no longer work. All sending should be done through `wp_mail()` instead.

Fixes #516