### PR TITLE
Update the PHP Docker image to 5.0.1

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -90,7 +90,7 @@ class Docker_Compose_Generator {
 	 */
 	protected function get_php_reusable() : array {
 		$version_map = [
-			'8.0' => 'humanmade/altis-local-server-php:5.0.0',
+			'8.0' => 'humanmade/altis-local-server-php:5.0.1',
 			'7.4' => 'humanmade/altis-local-server-php:4.2.0',
 		];
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -239,7 +239,7 @@ function get_config_domains( bool $include_aux_services = false ) : array {
 function mailhog_init( $phpmailer ) {
 	// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	$phpmailer->isSMTP();
-	$phpmailer->Host     = 'mailhog'; 
+	$phpmailer->Host     = 'mailhog';
 	$phpmailer->SMTPAuth = false;
 	$phpmailer->Port     = 1025;
 	// phpcs:enable


### PR DESCRIPTION
The sendmail binary is no longer needed since #519 and was removed in the Docker image in 5.0.1.