### PR TITLE
Display site URL after restarting

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -452,7 +452,9 @@ EOT
 		} );
 
 		if ( $return_val === 0 ) {
+			$site_url = $this->get_project_url();
 			$output->writeln( '<info>Restarted.</>' );
+			$output->writeln( '<info>To access your site visit:</> <comment>' . $site_url . '</>' );
 		} else {
 			$output->writeln( '<error>Failed to restart services.</>' );
 		}


### PR DESCRIPTION
When the server is started with `composer server start` the site URL is shown. The same is not true for restarting, and it can be really useful when debugging configuration changes.