### PR TITLE
Set redis container image version to v7.0

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -329,7 +329,7 @@ class Docker_Compose_Generator {
 	protected function get_service_redis() : array {
 		return [
 			'redis' => [
-				'image' => 'redis:3.2-alpine',
+				'image' => 'redis:7.0-alpine',
 				'container_name' => "{$this->project_name}-redis",
 				'ports' => [
 					'6379',


### PR DESCRIPTION
The Redis container is currently set to use a rather old version of Redis (v3.2), this sets the Redis container to use the latest Redis version (v7.0) which brings multiple security fixes and speed improvements.