### PR TITLE
Force order of precedence in ?? and &&

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -93,7 +93,7 @@ function bootstrap() {
 	add_filter( 'altis.search.create_package_id', __NAMESPACE__ . '\\set_search_package_id', 10, 3 );
 
 	// If we're on Codespaces, the native host will be localhost.
-	if ( $config['codespaces_integration'] ?? null && $_SERVER['HTTP_HOST'] === 'localhost' ) {
+	if ( ( $config['codespaces_integration'] ?? null ) && $_SERVER['HTTP_HOST'] === 'localhost' ) {
 		// Use forwarded host if we can.
 		if ( ! empty( $_SERVER['HTTP_X_FORWARDED_HOST'] ) ) {
 			// phpcs:ignore HM.Security.ValidatedSanitizedInput


### PR DESCRIPTION
The && operator happens before ?? so the localhost check is being evaluated together with the null. This change forces the intended behavior.

Current:

```php
if ( $config['codespaces_integration'] ?? null && $_SERVER['HTTP_HOST'] === 'localhost' ) {
```

Is the same as:

```php
if ( $config['codespaces_integration'] ?? ( null && $_SERVER['HTTP_HOST'] === 'localhost' ) ) {
```

Intended:

```php
if ( ( $config['codespaces_integration'] ?? null ) && $_SERVER['HTTP_HOST'] === 'localhost' ) {
```

See: https://www.php.net/manual/en/language.operators.precedence.php

While this looks to be related to Codespaces, it breaks Local Server for anything that uses the X-Forwarded-Host header because `codespaces_integration` is on by default. For example, piping external traffic to a Local Server application via Ngrok:

```sh
ngrok http --host-header=application.altis.dev 443
```

Will set HTTP_HOST to the temporary Ngrok subdomain, which doesn't exist in wp_blogs and will cause a redirect loop.