### PR TITLE
Enable xdebug only when starting server with `--xdebug`

### DIFF
--- a/docker/php.ini
+++ b/docker/php.ini
@@ -4,6 +4,9 @@
 sendmail_path = ${PHP_SENDMAIL_PATH}
 
 # XDebug
+zend_extension=xdebug
+
+[Xdebug]
 xdebug.mode = debug
 xdebug.start_with_request = yes
 xdebug.var_display_max_children = 1024

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -2,13 +2,3 @@
 
 # Set sendmail to use mailhog.
 sendmail_path = ${PHP_SENDMAIL_PATH}
-
-# XDebug
-zend_extension=xdebug
-
-[Xdebug]
-xdebug.mode = debug
-xdebug.start_with_request = yes
-xdebug.var_display_max_children = 1024
-xdebug.var_display_max_data = -1
-xdebug.var_display_max_depth = 10

--- a/docker/xdebug.ini
+++ b/docker/xdebug.ini
@@ -1,0 +1,9 @@
+# XDebug. Only loaded with local server is started with `--xdebug`.
+zend_extension=xdebug
+
+[Xdebug]
+xdebug.mode = debug
+xdebug.start_with_request = yes
+xdebug.var_display_max_children = 1024
+xdebug.var_display_max_data = -1
+xdebug.var_display_max_depth = 10

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -98,9 +98,9 @@ class Docker_Compose_Generator {
 	 */
 	protected function get_php_reusable() : array {
 		$version_map = [
-			'8.2' => 'humanmade/altis-local-server-php:8.2.3',
-			'8.1' => 'humanmade/altis-local-server-php:6.0.5',
-			'8.0' => 'humanmade/altis-local-server-php:5.0.4',
+			'8.2' => 'humanmade/altis-local-server-php:8.2.5',
+			'8.1' => 'humanmade/altis-local-server-php:6.0.7',
+			'8.0' => 'humanmade/altis-local-server-php:5.0.7',
 			'7.4' => 'humanmade/altis-local-server-php:4.2.5',
 		];
 
@@ -119,6 +119,17 @@ class Docker_Compose_Generator {
 		}
 
 		$image = $version_map[ $version ];
+
+		$volumes = [
+			$this->get_app_volume(),
+			"{$this->config_dir}/php.ini:/usr/local/etc/php/conf.d/altis.ini",
+			'socket:/var/run/php-fpm',
+			'tmp:/tmp',
+		];
+
+		if ( $this->args['xdebug'] !== 'off' ) {
+			$volumes[] = "{$this->config_dir}/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini";
+		}
 
 		$services = [
 			'init' => true,
@@ -148,12 +159,7 @@ class Docker_Compose_Generator {
 				"proxy:s3-{$this->hostname}",
 				"proxy:s3-{$this->project_name}.localhost",
 			],
-			'volumes' => [
-				$this->get_app_volume(),
-				"{$this->config_dir}/php.ini:/usr/local/etc/php/conf.d/altis.ini",
-				'socket:/var/run/php-fpm',
-				'tmp:/tmp',
-			],
+			'volumes' => $volumes,
 			'networks' => [
 				'proxy',
 				'default',


### PR DESCRIPTION
We're going to disabled the xdebug extension in production in https://github.com/humanmade/docker-wordpress-php/pull/190

This re-enables it. The extension now is also only enabled when starting the server with `--xdebug`.
