### PR TITLE
Fix updated links behaviour in latest docker compose

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -135,7 +135,9 @@ class Docker_Compose_Generator {
 			],
 			'image' => $image,
 			'links' => [
+				'db',
 				'db:db-read-replica',
+				's3',
 				's3:s3.localhost',
 			],
 			'external_links' => [


### PR DESCRIPTION
I had an issue after upgrading Docker Desktop just now to version 4.21.1.

The PHP server could no longer resolve the database on the hostname `db`.

My suspicion was a change in the behaviour of the `links` section of the `docker-compose.yml`, because we specify some additional links e.g. `db:db-read-replica` I wondered if that overrode the implicit `db` host name.

Making the following change got things working again after a server start. Certainly doesn't seem to do any harm anyway.

Everything else like redis still seems fine.