### PR TITLE
Throw an exception when asking for db information but the container isn't running

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -969,7 +969,7 @@ EOT;
 	/**
 	 * Return the Database connection details.
 	 *
-  	 * @throws \RuntimeException When the database container cannot be found.
+	 * @throws \RuntimeException When the database container cannot be found.
 	 * @return array
 	 */
 	private function get_db_connection_data() {

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -969,6 +969,7 @@ EOT;
 	/**
 	 * Return the Database connection details.
 	 *
+  	 * @throws \RuntimeException When the database container cannot be found.
 	 * @return array
 	 */
 	private function get_db_connection_data() {
@@ -1012,6 +1013,10 @@ EOT;
 		// Retrieve the forwarded ports using Docker and the container ID.
 		$ports = shell_exec( sprintf( "$command_prefix docker ps --format '{{.Ports}}' --filter id=%s", $db_container_id ) );
 		preg_match( '/([\d.]+):([\d]+)->.*/', trim( $ports ), $ports_matches );
+
+		if ( empty( $ports_matches ) ) {
+			throw new \RuntimeException( 'Could not retrieve information for the database. Is the container running?' );
+		}
 
 		return array_merge(
 			array_filter( $values ),


### PR DESCRIPTION
If you run `composer server db info` and the container isn't running, you'll get a PHP warning about an undefined array key:

<img width="747" alt="" src="https://github.com/humanmade/altis-local-server/assets/208434/8d7f23e7-9a3e-4a92-ab7c-c7a78f7f3670">

This change introduces an exception with a more helpful error message that's thrown if the database container information can't be fetched:

<img width="745" alt="" src="https://github.com/humanmade/altis-local-server/assets/208434/0f24d0d0-bbde-41fe-be32-6b418d661004">
