### PR TITLE
Fold server start TravisCI output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ before_script:
   - cd $HOME/test-root && composer require -W "$ALTIS_PACKAGE:dev-${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} as `jq \".\\\"packages-dev\\\"[] | select (.name==\\\"$ALTIS_PACKAGE\\\") | .version\" composer.lock | sed -e 's/\"//g;/^dev/q;s/\$/9/'`"
 
 script:
+  - fold_start server-start
   - cd $HOME/test-root && composer server start
+  - fold_end server-start
   - cd $HOME/test-root && composer server db info
   - cd $HOME/test-root && composer server db exec -- "select * from wp_site;"
   - cd $HOME/test-root && composer server status


### PR DESCRIPTION
Make `server start` output a single line when unopened.

Resolves #429 
