### PR TITLE
Update docker-wordpress-php images

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -98,9 +98,9 @@ class Docker_Compose_Generator {
 	 */
 	protected function get_php_reusable() : array {
 		$version_map = [
-			'8.2' => 'humanmade/altis-local-server-php:8.2.10',
-			'8.1' => 'humanmade/altis-local-server-php:6.0.11',
-			'8.0' => 'humanmade/altis-local-server-php:5.0.11',
+			'8.2' => 'humanmade/altis-local-server-php:8.2.11',
+			'8.1' => 'humanmade/altis-local-server-php:6.0.12',
+			'8.0' => 'humanmade/altis-local-server-php:5.0.12',
 			'7.4' => 'humanmade/altis-local-server-php:4.2.5',
 		];
 

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -98,9 +98,9 @@ class Docker_Compose_Generator {
 	 */
 	protected function get_php_reusable() : array {
 		$version_map = [
-			'8.2' => 'humanmade/altis-local-server-php:8.2.9',
-			'8.1' => 'humanmade/altis-local-server-php:6.0.10',
-			'8.0' => 'humanmade/altis-local-server-php:5.0.10',
+			'8.2' => 'humanmade/altis-local-server-php:8.2.10',
+			'8.1' => 'humanmade/altis-local-server-php:6.0.11',
+			'8.0' => 'humanmade/altis-local-server-php:5.0.11',
 			'7.4' => 'humanmade/altis-local-server-php:4.2.5',
 		];
 


### PR DESCRIPTION
# 8.2.11

## What's Changed
* [Backport v8.2-branch] Update Afterburner to 0.4.7 by @hm-backport in https://github.com/humanmade/docker-wordpress-php/pull/255


**Full Changelog**: https://github.com/humanmade/docker-wordpress-php/compare/8.2.10...8.2.11

# 8.2.10

## What's Changed
* [Backport v8.2-branch] Bump php from 8.2.11-fpm-bookworm to 8.2.12-fpm-bookworm by @hm-backport in https://github.com/humanmade/docker-wordpress-php/pull/247
* [Backport v8.2-branch] Update Afterburner 0.4.5 -> 0.4.6 by @hm-backport in https://github.com/humanmade/docker-wordpress-php/pull/251


**Full Changelog**: https://github.com/humanmade/docker-wordpress-php/compare/8.2.9...8.2.10

# 6.0.12

## What's Changed
* [Backport v6.0-branch] Update Afterburner to 0.4.7 by @hm-backport in https://github.com/humanmade/docker-wordpress-php/pull/254


**Full Changelog**: https://github.com/humanmade/docker-wordpress-php/compare/6.0.11...6.0.12

# 6.0.11

## What's Changed
* [Backport v6.0-branch] Update Afterburner 0.4.5 -> 0.4.6 by @hm-backport in https://github.com/humanmade/docker-wordpress-php/pull/250


**Full Changelog**: https://github.com/humanmade/docker-wordpress-php/compare/6.0.10...6.0.11

# 5.0.12

## What's Changed
* [Backport v5.0-branch] Update Afterburner to 0.4.7 by @hm-backport in https://github.com/humanmade/docker-wordpress-php/pull/253


**Full Changelog**: https://github.com/humanmade/docker-wordpress-php/compare/5.0.11...5.0.12

# 5.0.11

## What's Changed
* [Backport v5.0-branch] Update Afterburner 0.4.5 -> 0.4.6 by @hm-backport in https://github.com/humanmade/docker-wordpress-php/pull/249


**Full Changelog**: https://github.com/humanmade/docker-wordpress-php/compare/5.0.10...5.0.11