### PR TITLE
Add MySQL 8.0 support

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -1,4 +1,27 @@
-# Interacting with the Database
+# Database
+
+## Available Versions
+
+The available versions for MySQL are `5.7` and `8.0`
+
+MySQL defaults to version 8.0 however you can change the version in your config if your cloud environments have not yet been updated and you need to match them:
+
+```json
+{
+	"extra": {
+		"altis": {
+			"modules": {
+				"local-server": {
+					"mysql": "8.0"
+				}
+			}
+		}
+	}
+}
+```
+
+
+## Interacting with the Database
 
 You can log into MySQL and run any query in the default database (`wordpress`) by using:
 

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -371,7 +371,7 @@ class Docker_Compose_Generator {
 		];
 
 		$versions = array_keys( $version_map );
-		$version = (string) $this->get_config()['mysql'] ?? '8.0';
+		$version = (string) $this->get_config()['mysql'];
 
 		if ( ! in_array( $version, $versions, true ) ) {
 			echo sprintf(
@@ -910,6 +910,7 @@ class Docker_Compose_Generator {
 			'xray' => $modules['cloud']['xray'] ?? true,
 			'ignore-paths' => [],
 			'php' => '8.1',
+			'mysql' => '8.0',
 		];
 
 		return array_merge( $defaults, $modules['local-server'] ?? [] );

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -389,8 +389,8 @@ class Docker_Compose_Generator {
 		return [
 			'db' => [
 				'image' => $image,
-				// Use the mysql_native_password plugin for compatibility with MySQL 5.7 and suppress deprecation warnings.
-				'command' => $version == "8.0" ? "--default-authentication-plugin=mysql_native_password --log-error-suppression-list=MY-013360" : "",
+				// Suppress mysql_native_password deprecation warnings.
+				'command' => $version === '8.0' ? '--log-error-suppression-list=MY-013360' : '',
 				'container_name' => "{$this->project_name}-db",
 				'volumes' => [
 					'db-data:/var/lib/mysql',

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -365,9 +365,30 @@ class Docker_Compose_Generator {
 	 * @return array
 	 */
 	protected function get_service_db() : array {
+		$version_map = [
+			'5.7' => 'biarms/mysql:5.7',
+			'8.0' => 'mysql:8.0',
+		];
+
+		$versions = array_keys( $version_map );
+		$version = (string) $this->get_config()['mysql'] ?? '8.0';
+
+		if ( ! in_array( $version, $versions, true ) ) {
+			echo sprintf(
+				"The configured MySQL version \"%s\" is not supported.\nTry one of the following:\n  - %s\n",
+				// phpcs:ignore HM.Security.EscapeOutput.OutputNotEscaped
+				$version,
+				// phpcs:ignore HM.Security.EscapeOutput.OutputNotEscaped
+				implode( "\n  - ", $versions )
+			);
+			exit( 1 );
+		}
+
+		$image = $version_map[ $version ];
+
 		return [
 			'db' => [
-				'image' => 'biarms/mysql:5.7',
+				'image' => '',
 				'container_name' => "{$this->project_name}-db",
 				'volumes' => [
 					'db-data:/var/lib/mysql',

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -388,7 +388,7 @@ class Docker_Compose_Generator {
 
 		return [
 			'db' => [
-				'image' => '',
+				'image' => $image,
 				'container_name' => "{$this->project_name}-db",
 				'volumes' => [
 					'db-data:/var/lib/mysql',

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -389,6 +389,8 @@ class Docker_Compose_Generator {
 		return [
 			'db' => [
 				'image' => $image,
+				// Use the mysql_native_password plugin for compatibility with MySQL 5.7 and suppress deprecation warnings.
+				'command' => $version == "8.0" ? "--default-authentication-plugin=mysql_native_password --log-error-suppression-list=MY-013360" : "",
 				'container_name' => "{$this->project_name}-db",
 				'volumes' => [
 					'db-data:/var/lib/mysql',

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -389,7 +389,8 @@ class Docker_Compose_Generator {
 		return [
 			'db' => [
 				'image' => $image,
-				// Suppress mysql_native_password deprecation warnings.
+				// Suppress mysql_native_password deprecation warning
+				// Only affects in-place upgrades from MySQL 5.7 to 8.0.
 				'command' => $version === '8.0' ? '--log-error-suppression-list=MY-013360' : '',
 				'container_name' => "{$this->project_name}-db",
 				'volumes' => [


### PR DESCRIPTION
This PR adds MySQL 8.0 support. It also makes 8.0 the default version because 5.7 has reached end-of-life.

https://github.com/humanmade/altis-local-server/issues/671