### PR TITLE
Update example to v8

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -39,13 +39,13 @@ User:           wordpress
 Password:       wordpress
 
 Host:           0.0.0.0
-Port:           32775
+Port:           32809
 
-Version:        5.7.26-1debian9
-MySQL link:     mysql://wordpress:wordpress@0.0.0.0:32775/wordpress
+Version:        8.0
+MySQL link:     mysql://wordpress:wordpress@0.0.0.0:32809/wordpress
 ```
 
-Use `composer server db sequel` to open the database in Sequel Pro. This command can only be run under MacOS and requires [Sequel Pro](https://www.sequelpro.com/) to be installed on your computer.
+Use `composer server db sequel` to open the database in Sequel Ace. This command can only be run under MacOS and requires [Sequel Ace](https://sequel-ace.com//) to be installed on your computer.
 
 Use `composer server db exec -- "<command>"` to execute and output the results of an arbitrary SQL command:
 


### PR DESCRIPTION
Updates the info example to show MySQL v8 and replace mention of Sequel Pro with Sequel Ace.
