### PR TITLE
Add TablePlus command and improve Sequel Pro/Ace command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,6 @@ Note: Altis local-server automatically collects domains names to issue the SSL c
 * `composer server exec -- <command>` - Runs any command on the PHP container.
 * `composer server db` - Logs into MySQL on the DB container.
   * `composer server db info` - Print MySQL connection details.
-  * `composer server db (sequel|spf)` - Opens a connection to the database in [Sequel Pro](https://sequelpro.com) or Sequel Ace (https://sequel-ace.com/).
+  * `composer server db (sequel|spf)` - Opens a connection to the database in [Sequel Pro](https://sequelpro.com) or [Sequel Ace](https://sequel-ace.com/).
   * `composer server db (tableplus|tbp)` - Opens a connection to the database in [Table Plus](https://tableplus.com/).
 * `composer server import-uploads` - Syncs files from `content/uploads` to the S3 container.

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,5 +104,6 @@ Note: Altis local-server automatically collects domains names to issue the SSL c
 * `composer server exec -- <command>` - Runs any command on the PHP container.
 * `composer server db` - Logs into MySQL on the DB container.
   * `composer server db info` - Print MySQL connection details.
-  * `composer server db sequel` - Opens a connection to the database in [Sequel Pro](https://sequelpro.com).
+  * `composer server db (sequel|spf)` - Opens a connection to the database in [Sequel Pro](https://sequelpro.com) or Sequel Ace (https://sequel-ace.com/).
+  * `composer server db (tableplus|tbp)` - Opens a connection to the database in [Table Plus](https://tableplus.com/).
 * `composer server import-uploads` - Syncs files from `content/uploads` to the S3 container.

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -73,6 +73,7 @@ Open a shell:
 Database commands:
 	db                            Log into MySQL on the Database server
 	db sequel                     Generates an SPF file for Sequel Pro
+	db tableplus                  Opens TablePlus with the database connection
 	db info                       Prints out Database connection details
 	db exec -- "<query>"          Run and output the result of a SQL query.
 SSL commands:
@@ -680,6 +681,27 @@ EOT;
 				}
 
 				break;
+
+			case 'tableplus':
+				$connection_data = $this->get_db_connection_data();
+				$url = sprintf(
+					'mysql://%s:%s@%s:%s/%s',
+					$connection_data['MYSQL_USER'],
+					$connection_data['MYSQL_PASSWORD'],
+					$connection_data['HOST'],
+					$connection_data['PORT'],
+					$connection_data['MYSQL_DATABASE']
+				);
+				$url .= '?' . http_build_query( [
+					'name' => $this->get_project_subdomain(),
+					'env' => 'local',
+				] );
+				exec( sprintf( 'open "%s"', $url ), $null, $return_val );
+				if ( $return_val !== 0 ) {
+					$output->writeln( '<error>You must have TablePlus (https://tableplus.com/) installed to use this command</error>' );
+				}
+				break;
+
 			case 'exec':
 				$query = $input->getArgument( 'options' )[1] ?? null;
 				if ( empty( $query ) ) {

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -72,7 +72,7 @@ Open a shell:
 	shell
 Database commands:
 	db                            Log into MySQL on the Database server
-	db (sequel|spf)               Generates an SPF file for Sequel Pro
+	db (sequel|spf)               Opens Sequel Pro/Sequel Ace with the database connection
 	db (tableplus|tbp)            Opens TablePlus with the database connection
 	db info                       Prints out Database connection details
 	db exec -- "<query>"          Run and output the result of a SQL query.
@@ -679,7 +679,7 @@ EOT;
 
 				exec( "open $output_file_path", $null, $return_val );
 				if ( $return_val !== 0 ) {
-					$output->writeln( '<error>You must have Sequel Pro (https://www.sequelpro.com) installed to use this command</error>' );
+					$output->writeln( '<error>You must have Sequel Pro (https://www.sequelpro.com) or Sequel Ace (https://sequel-ace.com/) installed to use this command</error>' );
 				}
 
 				break;

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -72,8 +72,8 @@ Open a shell:
 	shell
 Database commands:
 	db                            Log into MySQL on the Database server
-	db sequel                     Generates an SPF file for Sequel Pro
-	db tableplus                  Opens TablePlus with the database connection
+	db (sequel|spf)               Generates an SPF file for Sequel Pro
+	db (tableplus|tbp)            Opens TablePlus with the database connection
 	db info                       Prints out Database connection details
 	db exec -- "<query>"          Run and output the result of a SQL query.
 SSL commands:
@@ -659,7 +659,9 @@ EOT
 EOT;
 				$output->write( $db_info );
 				break;
+
 			case 'sequel':
+			case 'spf':
 				if ( php_uname( 's' ) !== 'Darwin' ) {
 					$output->writeln( '<error>This command is only supported on MacOS, use composer server db info to see the database connection details.</error>' );
 					return 1;
@@ -683,6 +685,7 @@ EOT;
 				break;
 
 			case 'tableplus':
+			case 'tbp':
 				$connection_data = $this->get_db_connection_data();
 				$url = sprintf(
 					'mysql://%s:%s@%s:%s/%s',
@@ -714,10 +717,12 @@ EOT;
 				// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
 				passthru( "$base_command mysql --database=wordpress --user=root -e \"$query\"", $return_val );
 				break;
+
 			case null:
 				// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
 				passthru( "$base_command mysql --database=wordpress --user=root", $return_val );
 				break;
+
 			default:
 				$output->writeln( "<error>The subcommand $db is not recognized</error>" );
 				$return_val = 1;


### PR DESCRIPTION
* Adds a new `composer server db tableplus` command to launch [TablePlus](https://tableplus.com/)
* Adds `composer server db tbp` as alias for it, and `composer server db spf` as alias for `composer server db sequel`
* Adds [Sequel Ace](https://sequel-ace.com/) to help documentation as it's a newer maintained version