### PR TITLE
Adding alias for logs db command

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -580,6 +580,9 @@ EOT
 		} else {
 			$log = $input->getArgument( 'options' )[0];
 		}
+		if ( $log === 'mysql' || $log === 'sql' ) {
+			$log = 'db';
+		}	
 		$compose = $this->process( $this->get_compose_command( 'logs --tail=100 -f ' . $log ), 'vendor', $this->get_env() );
 		$compose->setTty( posix_isatty( STDOUT ) );
 		$compose->setTimeout( 0 );

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -582,7 +582,7 @@ EOT
 		}
 		if ( $log === 'mysql' || $log === 'sql' ) {
 			$log = 'db';
-		}	
+		}
 		$compose = $this->process( $this->get_compose_command( 'logs --tail=100 -f ' . $log ), 'vendor', $this->get_env() );
 		$compose->setTty( posix_isatty( STDOUT ) );
 		$compose->setTimeout( 0 );


### PR DESCRIPTION
Adding mysql and sql as aliases for `composer server logs db` command. fixes #272 