### PR TITLE
Fixing 404s on subdomains with dashes on it

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -372,7 +372,7 @@ class Docker_Compose_Generator {
 					'traefik.port=8080',
 					'traefik.protocol=https',
 					'traefik.docker.network=proxy',
-					"traefik.frontend.rule=HostRegexp:{$this->hostname},{subdomain:[A-Za-z0-9-_]+}.{$this->hostname}{$domains}",
+					"traefik.frontend.rule=HostRegexp:{$this->hostname},{subdomain:[A-Za-z0-9.-]+}.{$this->hostname}{$domains}",
 					"traefik.domain={$this->hostname},*.{$this->hostname}{$domains}",
 				],
 				'environment' => [
@@ -642,7 +642,7 @@ class Docker_Compose_Generator {
 					'traefik.client.port=9000',
 					'traefik.client.protocol=http',
 					'traefik.client.frontend.passHostHeader=false',
-					"traefik.client.frontend.rule=HostRegexp:{$this->hostname},{subdomain:[A-Za-z0-9-_]+}.{$this->hostname},s3-{$this->hostname},localhost,s3-{$this->project_name}.localhost;PathPrefix:/uploads;AddPrefix:/{$this->bucket_name}",
+					"traefik.client.frontend.rule=HostRegexp:{$this->hostname},{subdomain:[A-Za-z0-9.-]+}.{$this->hostname},s3-{$this->hostname},localhost,s3-{$this->project_name}.localhost;PathPrefix:/uploads;AddPrefix:/{$this->bucket_name}",
 					"traefik.domain=s3-{$this->hostname},s3-console-{$this->hostname}",
 				],
 			],
@@ -687,7 +687,7 @@ class Docker_Compose_Generator {
 					'traefik.port=8080',
 					'traefik.protocol=http',
 					'traefik.docker.network=proxy',
-					"traefik.frontend.rule=HostRegexp:{$this->hostname},{subdomain:[A-Za-z0-9-_]+}.{$this->hostname};PathPrefix:/tachyon;ReplacePathRegex:^/tachyon/(.*) /uploads/$$1",
+					"traefik.frontend.rule=HostRegexp:{$this->hostname},{subdomain:[A-Za-z0-9.-]+}.{$this->hostname};PathPrefix:/tachyon;ReplacePathRegex:^/tachyon/(.*) /uploads/$$1",
 				],
 				'environment' => [
 					'AWS_REGION' => 'us-east-1',


### PR DESCRIPTION
Fixed the regex to allow dashes on subdomains, previous regex didn't march them. This was reported on issue [#265](https://github.com/humanmade/altis-local-server/issues/265)

[ML] To validate I created a range of subdomains with hyphens.

![CleanShot 2024-12-17 at 16 12 50@2x](https://github.com/user-attachments/assets/5cd008b0-8767-49c1-80e4-4ab272b0ed60)


---

## For Altis Team Use

### Completion Checklist

Is this ticket done? See
[the Play Book Definition of Done](https://playbook.hmn.md/play/product/definition-of-done-2/)

- [x] Has the acceptance criteria been met?
- [x] Is the documentation updated (including README)?
- [x] Do any code/documentation changes meet project standards?
- [ ] Are automatic tests in place to verify the fix or new functionality?
  - [x] Or are manual tests documented (at least on this ticket)?
- [x] Are any Playbook/Handbook pages updated?
- [x] Has a new module release (patch/minor) been created/scheduled?
- [x] Have the appropriate `backport` labels been added to the PR?
- [ ] Is there a roll-out (and roll-back) plan if required?


