### PR TITLE
Updates nginx to `3.5.8` and disables rate limiting

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -306,7 +306,7 @@ class Docker_Compose_Generator {
 
 		return [
 			'nginx' => [
-				'image' => 'humanmade/altis-local-server-nginx:3.5.4',
+				'image' => 'humanmade/altis-local-server-nginx:3.5.8',
 				'container_name' => "{$this->project_name}-nginx",
 				'networks' => [
 					'proxy',
@@ -335,6 +335,8 @@ class Docker_Compose_Generator {
 					'GZIP_STATUS' => 'on',
 					// Increase read response timeout when debugging.
 					'READ_TIMEOUT' => ( $this->args['xdebug'] ?? 'off' ) !== 'off' ? '9000s' : '60s',
+					// Disables rate limiting.
+					'PHP_PUBLIC_POOL_ENABLE_RATE_LIMIT' => 'false',
 				],
 			],
 		];


### PR DESCRIPTION
- Fixes https://github.com/humanmade/product-dev/issues/1525 by disabling rate limiting on `v3.5.8`.

### TESTS ON LOCAL USING `docker-wordpress-nginx 3.5.8`
```
wisdomhambolu@Wisdoms-MacBook-Pro-2 test-root % echo $ALTIS_PACKAGE
altis/cms

wisdomhambolu@Wisdoms-MacBook-Pro-2 test-root % composer dev-tools codecept run -p vendor/$ALTIS_PACKAGE/tests
Running 1 suite(s), (acceptance)..
Flushing the cache...
Running "acceptance" test suite..

What's next?
  Try Docker Debug for seamless, persistent debugging tools in any container or image → docker debug test-root-db
  Learn more at https://docs.docker.com/go/debug-cli/
Starting headless "chrome" browser container..
7da7896316b616033ed25f1e53cc8d52c6d133ed5c05625ec5c5879ea96735af
Running Codeception..
Codeception PHP Testing Framework v4.2.2 https://helpukrainewin.org
Powered by PHPUnit 9.6.19 by Sebastian Bergmann and contributors.

Acceptance Tests (2) ---------------------------------------
✔ SignupsCest: Test I want to manage my network signups. (12.56s)
✔ SiteCest: Test I want to manage my network sites. (29.24s)
------------------------------------------------------------


Time: 01:14.607, Memory: 22.00 MB

OK (2 tests, 3 assertions)
Flushing the cache...
Removing test databases..

What's next?
  Try Docker Debug for seamless, persistent debugging tools in any container or image → docker debug test-root-db
  Learn more at https://docs.docker.com/go/debug-cli/
Removing headless browser container..
```