### PR TITLE
Add Node.js Support

### DIFF
--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -8,18 +8,18 @@ Node.js can be enabled in Local Server by adding `extra.altis.modules.local-serv
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"local-server": {
-					"nodejs": {
-            "path": "../altis-nodejs-skeleton",
-            "version": "21.1"
-          }
-				}
-			}
-		}
-	}
+   "extra":{
+      "altis":{
+         "modules":{
+            "local-server":{
+               "nodejs":{
+                  "path":"../altis-nodejs-skeleton",
+                  "version":"21.1"
+               }
+            }
+         }
+      }
+   }
 }
 ```
 

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -1,0 +1,27 @@
+# Node.js
+
+Altis supports running Node.js applications alongside WordPress, utilizing WordPress as a headless API.
+
+## Enabling Node.js in Local Server
+
+Node.js can be enabled in Local Server by adding `extra.altis.modules.local-server.nodejs` in the project's `composer.json`
+
+```json
+{
+	"extra": {
+		"altis": {
+			"modules": {
+				"local-server": {
+					"nodejs": {
+            "path": "../altis-nodejs-skeleton"
+          }
+				}
+			}
+		}
+	}
+}
+```
+
+path refers to the relative path of the project's front-end code.
+
+This will make the application available at nodejs-my-project.altis.dev.

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -13,7 +13,8 @@ Node.js can be enabled in Local Server by adding `extra.altis.modules.local-serv
 			"modules": {
 				"local-server": {
 					"nodejs": {
-            "path": "../altis-nodejs-skeleton"
+            "path": "../altis-nodejs-skeleton",
+            "version": "21.1"
           }
 				}
 			}
@@ -22,6 +23,7 @@ Node.js can be enabled in Local Server by adding `extra.altis.modules.local-serv
 }
 ```
 
-path refers to the relative path of the project's front-end code.
+`path` refers to the relative path of the project's front-end code.
+`version` refers to the version of Node.js to use
 
 This will make the application available at nodejs-my-project.altis.dev.

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -13,8 +13,7 @@ Node.js can be enabled in Local Server by adding `extra.altis.modules.local-serv
          "modules":{
             "local-server":{
                "nodejs":{
-                  "path":"../altis-nodejs-skeleton",
-                  "version":"21.1"
+                  "path":"../altis-nodejs-skeleton"
                }
             }
          }
@@ -24,6 +23,12 @@ Node.js can be enabled in Local Server by adding `extra.altis.modules.local-serv
 ```
 
 `path` refers to the relative path of the project's front-end code.
-`version` refers to the version of Node.js to use
 
-This will make the application available at nodejs-my-project.altis.dev.
+## Setting Node.js Version
+Similar to configuring the Altis infrastructure, the Local Server determines the Node.js version to use based on the `engines.node` value found in the `package.json` at the specified `path`.
+
+## Running Development Server
+Once configured, the Local Server executes `npm run dev` inside the Node.js container at the specified path. This command watches for changes and recompiles necessary files.
+
+## Accessing the Application
+This setup makes the application accessible at `https://nodejs-{project-name}.altis.dev`.

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -322,6 +322,13 @@ EOT
 		$output->writeln( '<info>Startup completed.</>' );
 		$output->writeln( '<info>To access your site visit:</> <comment>' . $site_url . '</>' );
 
+		if (static::get_composer_config()['nodejs'] ?? false) {
+			$tld = $this->get_project_tld();
+			$subdomain = $this->get_project_subdomain();
+			$hostname = $subdomain . '.' . $tld;
+			$output->writeln( '<info>To access your Node.js site visit:</> <comment>https://nodejs-' . $hostname . '</>' );
+		}
+
 		$this->check_host_entries( $input, $output );
 
 		return 0;

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -322,7 +322,7 @@ EOT
 		$output->writeln( '<info>Startup completed.</>' );
 		$output->writeln( '<info>To access your site visit:</> <comment>' . $site_url . '</>' );
 
-		if (static::get_composer_config()['nodejs'] ?? false) {
+		if ( static::get_composer_config()['nodejs'] ?? false ) {
 			$tld = $this->get_project_tld();
 			$subdomain = $this->get_project_subdomain();
 			$hostname = $subdomain . '.' . $tld;

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -577,6 +577,7 @@ EOT
 					'redis',
 					's3',
 					'xray',
+					'nodejs',
 				],
 				0
 			);

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -125,10 +125,6 @@ class Docker_Compose_Generator {
 			'tmp:/tmp',
 		];
 
-		if ( $this->get_config()['nodejs'] ) {
-			$volumes[] = "{$this->root_dir}/node_modules:/var/www/html/node_modules";
-		}
-
 		if ( $this->args['xdebug'] !== 'off' ) {
 			$volumes[] = "{$this->config_dir}/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini";
 		}
@@ -251,7 +247,7 @@ class Docker_Compose_Generator {
 
 		return [
 			'nodejs' => [
-				'image' => 'node:21-bookworm-slim', 
+				'image' => 'node:21-bookworm-slim',
 				'container_name' => "{$this->project_name}-nodejs",
 				'ports' => [
 					'3000',

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -249,7 +249,7 @@ class Docker_Compose_Generator {
 
 		return [
 			'nodejs' => [
-				'image' => "node:{$version}-bookworm-slim",
+				'image' => "node:{$version}-bookworm",
 				'container_name' => "{$this->project_name}-nodejs",
 				'ports' => [
 					'3000',
@@ -262,6 +262,15 @@ class Docker_Compose_Generator {
 				'networks' => [
 					'proxy',
 					'default',
+				],
+				'healthcheck' => [
+					'test' => [
+						'CMD-SHELL',
+						'curl --silent --fail localhost:3000 || exit 1',
+					],
+					'interval' => '5s',
+					'timeout' => '5s',
+					'retries' => 25,
 				],
 				'labels' => [
 					'traefik.frontend.priority=1',

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -249,7 +249,7 @@ class Docker_Compose_Generator {
 
 		return [
 			'nodejs' => [
-				'image' => "node:{$version}-bookworm",
+				'image' => "node:{$version}-bookworm-slim",
 				'container_name' => "{$this->project_name}-nodejs",
 				'ports' => [
 					'3000',
@@ -262,15 +262,6 @@ class Docker_Compose_Generator {
 				'networks' => [
 					'proxy',
 					'default',
-				],
-				'healthcheck' => [
-					'test' => [
-						'CMD-SHELL',
-						'curl --silent --fail localhost:3000 || exit 1',
-					],
-					'interval' => '5s',
-					'timeout' => '5s',
-					'retries' => 25,
 				],
 				'labels' => [
 					'traefik.frontend.priority=1',

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -245,7 +245,9 @@ class Docker_Compose_Generator {
 	protected function get_service_nodejs() : array {
 		$config = $this->get_config();
 
-		$version = (string) $this->get_config()['nodejs']['version'] ?? '20';
+		// Read package.json from nodejs.path to get the Node.js version to use
+		$package_json = json_decode( file_get_contents( "{$config['nodejs']['path']}/package.json" ), true );
+		$version = $package_json['engines']['node'] ?? '20';
 
 		return [
 			'nodejs' => [

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -245,7 +245,7 @@ class Docker_Compose_Generator {
 	protected function get_service_nodejs() : array {
 		$config = $this->get_config();
 
-		// Read package.json from nodejs.path to get the Node.js version to use
+		// Read package.json from nodejs.path to get the Node.js version to use.
 		$package_json = json_decode( file_get_contents( "{$config['nodejs']['path']}/package.json" ), true );
 		$version = $package_json['engines']['node'] ?? '20';
 
@@ -257,7 +257,7 @@ class Docker_Compose_Generator {
 					'3000',
 				],
 				'volumes' => [
-					"../{$config['nodejs']['path']}/:/usr/src/app"
+					"../{$config['nodejs']['path']}/:/usr/src/app",
 				],
 				'working_dir' => '/usr/src/app',
 				'command' => 'npm run dev',
@@ -277,7 +277,7 @@ class Docker_Compose_Generator {
 					'ALTIS_ENVIRONMENT_NAME' => $this->project_name,
 					'ALTIS_ENVIRONMENT_TYPE' => 'local',
 				],
-			]
+			],
 		];
 	}
 

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -245,9 +245,11 @@ class Docker_Compose_Generator {
 	protected function get_service_nodejs() : array {
 		$config = $this->get_config();
 
+		$version = (string) $this->get_config()['nodejs']['version'] ?? '20';
+
 		return [
 			'nodejs' => [
-				'image' => 'node:21-bookworm-slim',
+				'image' => "node:{$version}-bookworm-slim",
 				'container_name' => "{$this->project_name}-nodejs",
 				'ports' => [
 					'3000',

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -260,7 +260,7 @@ class Docker_Compose_Generator {
 					"../{$config['nodejs']['path']}/:/usr/src/app",
 				],
 				'working_dir' => '/usr/src/app',
-				'command' => 'npm run dev',
+				'command' => 'sh -c "npm install && npm run dev"',
 				'networks' => [
 					'proxy',
 					'default',

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -273,6 +273,10 @@ class Docker_Compose_Generator {
 					"traefik.frontend.rule=HostRegexp:nodejs-{$this->hostname}",
 					"traefik.domain=nodejs-{$this->hostname}",
 				],
+				'environment' => [
+					'ALTIS_ENVIRONMENT_NAME' => $this->project_name,
+					'ALTIS_ENVIRONMENT_TYPE' => 'local',
+				],
 			]
 		];
 	}


### PR DESCRIPTION
To enable Node.js in Local Server, add the following configuration in the project's `composer.json`:
```json
{
  "extra": {
    "altis": {
      "modules": {
        "local-server": {
          "nodejs": {
            "path": "../altis-nodejs-skeleton"
          }
        }
      }
    }
  }
}
```

`path` refers to the frontend code directory

- [x] Add Node.js container when Node.js configuration exists
- [x] Add documentation
- [x] ~~Add healthcheck~~
- [x] Echo Node.js URL when startup completes
- [x] Add config to setup Node.js version to use
     - Read from ~~`extra.altis.modules.local-server.nodejs.version`~~ `{$app}/package.json`
     - Based off how we set version in TFA https://github.com/humanmade/terraform-app-stack/blob/5a70129f5699b663347be2c2919b63ba98ab6015/modules/nodejs/buildspec.yml#L18

https://github.com/humanmade/product-dev/issues/1589