### PR TITLE
Issue 721 Remove support for MySQL 5.7

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -2,24 +2,7 @@
 
 ## Available Versions
 
-The available versions for MySQL are `5.7` and `8.0`
-
-MySQL defaults to version 8.0 however you can change the version in your config if your cloud environments have not yet been updated
-and you need to match them:
-
-```json
-{
-    "extra": {
-        "altis": {
-            "modules": {
-                "local-server": {
-                    "mysql": "8.0"
-                }
-            }
-        }
-    }
-}
-```
+Altis supports MySQL version `8.0`.
 
 ## Interacting with the Database
 

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -411,7 +411,6 @@ class Docker_Compose_Generator {
 	 */
 	protected function get_service_db() : array {
 		$version_map = [
-			'5.7' => 'biarms/mysql:5.7',
 			'8.0' => 'mysql:8.0',
 		];
 


### PR DESCRIPTION
Remove MySQL 5.7 as an option in docker compose.
Remove reference to 5.7 in docs.
Fixes https://github.com/humanmade/altis-local-server/issues/721
