### PR TITLE
Revert "Update symfony/yaml requirement from ~5.4.40 to ~7.1.4"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require": {
 		"php": ">=7.1",
 		"composer-plugin-api": "^1.1 || ^2.0",
-		"symfony/yaml": "~7.1.4"
+		"symfony/yaml": "~5.4.40"
 	},
 	"extra": {
 		"class": "Altis\\Local_Server\\Composer\\Plugin",


### PR DESCRIPTION
Reverts humanmade/altis-local-server#725

Looks like there's a compatibility problem with Codeception and that whole chain.