### PR TITLE
Update PHP containers to get WP CLI update

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -100,7 +100,7 @@ class Docker_Compose_Generator {
 		$version_map = [
 			'8.3' => 'humanmade/altis-local-server-php:8.3.9',
 			'8.2' => 'humanmade/altis-local-server-php:8.2.23',
-			'8.1' => 'humanmade/altis-local-server-php:6.0.18',
+			'8.1' => 'humanmade/altis-local-server-php:6.0.19',
 		];
 
 		$versions = array_keys( $version_map );

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -98,9 +98,9 @@ class Docker_Compose_Generator {
 	 */
 	protected function get_php_reusable() : array {
 		$version_map = [
-			'8.3' => 'humanmade/altis-local-server-php:8.3.8',
-			'8.2' => 'humanmade/altis-local-server-php:8.2.22',
-			'8.1' => 'humanmade/altis-local-server-php:6.0.17',
+			'8.3' => 'humanmade/altis-local-server-php:8.3.9',
+			'8.2' => 'humanmade/altis-local-server-php:8.2.23',
+			'8.1' => 'humanmade/altis-local-server-php:6.0.18',
 		];
 
 		$versions = array_keys( $version_map );


### PR DESCRIPTION
- Updates the PHP containers to the latest versions to get the latest WP CLI update.
- Update to 6.0.19 to pick up the v8js download fix. ref: https://github.com/humanmade/docker-wordpress-php/pull/325