### PR TITLE
Turns out we were still defaulting to PHP 8.1

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -960,7 +960,7 @@ class Docker_Compose_Generator {
 			'afterburner' => false,
 			'xray' => $modules['cloud']['xray'] ?? true,
 			'ignore-paths' => [],
-			'php' => '8.1',
+			'php' => '8.2',
 			'mysql' => '8.0',
 			'nodejs' => $modules['nodejs'] ?? false,
 		];


### PR DESCRIPTION
This updates the default to PHP 8.2
Addresses https://github.com/humanmade/product-dev/issues/1648