### PR TITLE
Clarify how PHP versions are specified.

### DIFF
--- a/docs/php-version.md
+++ b/docs/php-version.md
@@ -19,6 +19,9 @@ To change the PHP version use the Local Server module configuration to set the `
 }
 ```
 
+**Note**: Only the major and minor versions (x.y) should be listed. We will use the latest patch version we have tested and made
+available both locally and in the cloud.
+
 Altis will always default to the _highest_ supported version of PHP unless support is marked as
 experimental. [See the PHP compatibility chart here](docs://guides/updating-php/README.md) to see which version of PHP your version
 of Local Server will be running on by default, and which other versions are available.

--- a/docs/php-version.md
+++ b/docs/php-version.md
@@ -19,8 +19,8 @@ To change the PHP version use the Local Server module configuration to set the `
 }
 ```
 
-**Note**: Only the major and minor versions (x.y) should be listed. We will use the latest patch version we have tested and made
-available both locally and in the cloud.
+**Note**: Only the major and minor versions (x.y) should be specified. Altis automatically manages and updates the patch version
+as part of regular maintenance.
 
 Altis will always default to the _highest_ supported version of PHP unless support is marked as
 experimental. [See the PHP compatibility chart here](docs://guides/updating-php/README.md) to see which version of PHP your version


### PR DESCRIPTION
Clarify how the PHP versions need to be specified in `composer.json`

Fixes https://github.com/humanmade/altis-documentation/issues/417