### PR TITLE
Add `default-site-url` override option for WP CLI commands

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,3 +43,26 @@ composer server cli -- db import database.sql
 
 **Note:** For privacy reasons any database backups that are version controlled should have any personally identifiable information
 removed and extra care should be taken to avoid committing database backup files containing personal data.
+
+### Default Site URL
+
+Altis supports specifying a default site URL that can be different from the root URL of the local environment. This is particularly useful in scenarios where the default site resides at a subpath rather than the root of the local URL. By configuring this option, users can ensure WP-CLI commands operate on the correct site by default.
+
+You can define the default site URL in your project’s `composer.json` file under the `extra.altis.modules.local-server.default-site-url` property. Here’s an example:
+
+
+```json
+{
+    "extra": {
+        "altis": {
+            "modules": {
+                "local-server": {
+                    "default-site-url": "my-site.altis.dev/en/"
+                }
+            }
+        }
+    }
+}
+```
+
+Note: By setting `default-site-url`, the default site URL will only be overridden for WP-CLI commands. It does not affect other components or tools in your environment.

--- a/docs/default-site-url.md
+++ b/docs/default-site-url.md
@@ -1,0 +1,22 @@
+# Default Site URL
+
+Altis supports specifying a default site URL that can be different from the root URL of the local environment. This is particularly useful in scenarios where the default site resides at a subpath rather than the root of the local URL. By configuring this option, users can ensure WP-CLI commands operate on the correct site by default.
+
+You can define the default site URL in your project’s `composer.json` file under the `extra.altis.modules.local-server.default-site-url` property. Here’s an example:
+
+
+```json
+{
+    "extra": {
+        "altis": {
+            "modules": {
+                "local-server": {
+                    "default-site-url": "my-site.altis.dev/en/"
+                }
+            }
+        }
+    }
+}
+```
+
+Note: By setting `default-site-url`, the default site URL will only be overridden for WP-CLI commands. It does not affect other components or tools in your environment.

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -492,7 +492,7 @@ EOT
 			}
 		}
 
-		if ( ! $passed_url && $program === 'wp' ) {
+		if ( ! $passed_url && ( $program === 'wp' || $options[0] === 'wp' ) ) {
 			$default_site_url ? $options[] = '--url=' . sprintf( static::set_url_scheme( 'https://%s/' ), $default_site_url ) : $options[] = '--url=' . $site_url;
 		}
 

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -481,6 +481,8 @@ EOT
 	protected function exec( InputInterface $input, OutputInterface $output, ?string $program = null ) {
 		$site_url = $this->get_project_url();
 		$options = $input->getArgument( 'options' );
+		$config = $this->get_composer_config();
+		$default_site_url = $config['default_site_url'];
 
 		$passed_url = false;
 		foreach ( $options as $option ) {
@@ -491,7 +493,7 @@ EOT
 		}
 
 		if ( ! $passed_url && $program === 'wp' ) {
-			$options[] = '--url=' . $site_url;
+			$default_site_url ? $options[] = '--url=' . sprintf( static::set_url_scheme( 'https://%s/' ), $default_site_url ) : $options[] = '--url=' . $site_url;
 		}
 
 		// Escape all options. Because the shell is going to strip the

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -482,7 +482,7 @@ EOT
 		$site_url = $this->get_project_url();
 		$options = $input->getArgument( 'options' );
 		$config = $this->get_composer_config();
-		$default_site_url = $config['default_site_url'];
+		$default_site_url = $config['default_site_url'] ?? null;
 
 		$passed_url = false;
 		foreach ( $options as $option ) {

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -482,7 +482,7 @@ EOT
 		$site_url = $this->get_project_url();
 		$options = $input->getArgument( 'options' );
 		$config = $this->get_composer_config();
-		$default_site_url = $config['default_site_url'] ?? null;
+		$default_site_url = $config['default-site-url'] ?? null;
 
 		$passed_url = false;
 		foreach ( $options as $option ) {


### PR DESCRIPTION
- Delivers https://github.com/humanmade/altis-local-server/issues/745
- While working on this I realised that when a `wp` command is run via `composer server exec -- wp` the site url set in `--url` does not get used by the wp command, so I added code to enable that in https://github.com/humanmade/altis-local-server/pull/773/commits/6626d547f22ad4cf91073fe65a636535400a0592 to ensure that the `default-site-url` also applies to WP-CLI commands run via `composer server exec -- wp`.