### PR TITLE
Add a create-alias command to local server

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -120,8 +120,8 @@ in `composer.json`, namely the `altis.modules.local-server` tree, specifically t
 * `composer server logs <service>` - Tail the logs from a given service, defaults to `php`, available options
   are `nginx`, `php`, `db`, `redis`, `cavalcade`, `tachyon`, `s3` and `elasticsearch`.
 * `composer server shell` - Logs in to the PHP container.
-* `composer server cli|wp -- <command>` - Runs a WP CLI command, you should omit the `wp` for example `composer server cli -- 
-info` or run `composer server wp -- info`.
+* `composer server cli|wp -- <command>` - Runs a WP CLI command. Use either `cli` or `wp`. For example,
+  `composer server cli -- info` or `composer server wp -- info`. Do not include `wp` in `<command>`.
   * `composer server cli -- db import database.sql` - Imports a database file located in the project root.
 * `composer server create-alias` - Create a WP CLI alias. Useful if you have WP CLI installed locally.
 * `composer server exec -- <command>` - Runs any command on the PHP container.

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,8 +120,10 @@ in `composer.json`, namely the `altis.modules.local-server` tree, specifically t
 * `composer server logs <service>` - Tail the logs from a given service, defaults to `php`, available options
   are `nginx`, `php`, `db`, `redis`, `cavalcade`, `tachyon`, `s3` and `elasticsearch`.
 * `composer server shell` - Logs in to the PHP container.
-* `composer server cli -- <command>` - Runs a WP CLI command, you should omit the `wp` for example `composer server cli -- info`
+* `composer server cli|wp -- <command>` - Runs a WP CLI command, you should omit the `wp` for example `composer server cli -- 
+info` or run `composer server wp -- info`.
   * `composer server cli -- db import database.sql` - Imports a database file located in the project root.
+* `composer server create-alias` - Create a WP CLI alias. Useful if you have WP CLI installed locally.
 * `composer server exec -- <command>` - Runs any command on the PHP container.
 * `composer server db` - Logs into MySQL on the DB container.
   * `composer server db info` - Print MySQL connection details.

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -1320,8 +1320,8 @@ EOT;
 	 * We'll add the default url parameter like we do for running wp cli commands inside the container.
 	 * Otherwise, it will need to be specified every time by the user.
 	 *
-	 * @param InputInterface  $input
-	 * @param OutputInterface $output
+	 * @param InputInterface  $input Input from the console
+	 * @param OutputInterface $output Output to the console
 	 *
 	 * @return int
 	 */
@@ -1336,7 +1336,7 @@ EOT;
   url: {$this->get_project_url()}
 EOT;
 
-		// first lets see if the file already exists and whether it already contains a local alias
+		// first lets see if the file already exists and whether it already contains a local alias.
 		$local_alias_file = getcwd() . '/wp-cli.local.yml';
 		if ( file_exists( $local_alias_file ) ) {
 			$local_alias_contents = file_get_contents( $local_alias_file );
@@ -1360,7 +1360,7 @@ EOT
 			return $return_val;
 		}
 
-		// if the file doesn't exist, we'll add it
+		// if the file doesn't exist, we'll add it.
 		$output->writeln( 'Generating wp-cli.local.yml...' );
 		file_put_contents( $local_alias_file, $local_alias );
 		$output->writeln( 'Done!' );

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -65,7 +65,7 @@ Destroy the local development server:
 View status of the local development server:
 	status
 Run WP CLI command:
-	cli|wp -- <command>              eg: cli -- post list --debug
+	cli|wp -- <command>           eg: cli -- post list --debug
 Create a WP CLI alias. Useful if you have WP CLI installed locally:
 	create-alias
 Run any shell command from the PHP container:
@@ -1346,12 +1346,13 @@ EOT;
 			} else {
 				// file exists but doesn't contain @local. Suggest how they can add it.
 				$output->writeln( <<<"EOT"
-It looks like you already have a wp-cli.local.yml file but it does not contain a `@local` alias.
+It looks like you already have a wp-cli.local.yml file but it does not contain an `@local` alias.
 You can add the following to your wp-cli.local.yml file to use the local alias:
 
 $local_alias
 
-You can then run `wp @local` to use the local alias.
+You can then run WP CLI commands using the following syntax:
+`wp @local cli info`
 EOT
 				);
 			}
@@ -1367,7 +1368,8 @@ EOT
 		$output->writeln( <<<EOT
 
 A wp-cli.local.yml file has been created in the root of your project.
-You can now run `wp @local` to use the local alias.
+You can now run WP CLI commands using the following syntax:
+`wp @local cli info`
 EOT
 		);
 


### PR DESCRIPTION
This adds a `create-alias` command to local server that will generate a
wp-cli.local.yml file in the root of the project. This file will contain an
alias for the php docker container that can be used with wp-cli commands.

The command is conservative in that it will not overwrite an existing wp-cli.local.yml file.

This adds an alias to the `cli` command so that you can use `composer server wp` too.

Fixes: https://github.com/humanmade/altis-local-server/issues/221

The command will not overwrite an existing wp-cli.local.yml file
If it detects there is no alias command already in the file it will issue instructions on how to add it.
If no file exists it will create one.

---

## For Altis Team Use

### Completion Checklist

Is this ticket done? See
[the Play Book Definition of Done](https://playbook.hmn.md/play/product/definition-of-done-2/)

- [x] Has the acceptance criteria been met?
- [x] Is the documentation updated (including README)?
- [x] Do any code/documentation changes meet project standards?
- [ ] Are automatic tests in place to verify the fix or new functionality?
  - [x] Or are manual tests documented (at least on this ticket)?
- [ ] Are any Playbook/Handbook pages updated?
- [ ] Has a new module release (patch/minor) been created/scheduled?
- [x] Have the appropriate `backport` labels been added to the PR?
- [ ] Is there a roll-out (and roll-back) plan if required?


