### PR TITLE
Make sure s3 bucket is created as a dep of PHP

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -146,6 +146,9 @@ class Docker_Compose_Generator {
 				'mailhog' => [
 					'condition' => 'service_started',
 				],
+				's3-create-bucket' => [
+					'condition' => 'service_completed_successfully',
+				],
 			],
 			'image' => $image,
 			'links' => [
@@ -627,8 +630,8 @@ class Docker_Compose_Generator {
 						'-f',
 						'http://localhost:9000/minio/health/live',
 					],
-					'interval' => '30s',
-					'timeout' => '20s',
+					'interval' => '5s',
+					'timeout' => '5s',
 					'retries' => 3,
 				],
 				'labels' => [
@@ -646,12 +649,29 @@ class Docker_Compose_Generator {
 					"traefik.domain=s3-{$this->hostname},s3-console-{$this->hostname}",
 				],
 			],
+			's3-create-bucket' => [
+				'image' => 'minio/mc:RELEASE.2021-09-02T09-21-27Z',
+				'depends_on' => [
+					's3' => [
+						'condition' => 'service_healthy',
+					],
+				],
+				'links' => [
+					's3',
+				],
+				'environment' => [
+					'MC_HOST_local' => 'http://admin:password@s3:9000',
+				],
+				'entrypoint' => "/bin/sh -c \"mc mb -p local/{$this->bucket_name} && mc policy set public local/{$this->bucket_name}\"",
+			],
 			's3-sync-to-host' => [
 				'image' => 'minio/mc:RELEASE.2021-09-02T09-21-27Z',
 				'container_name' => "{$this->project_name}-s3-sync",
 				'restart' => 'unless-stopped',
 				'depends_on' => [
-					's3',
+					's3-create-bucket' => [
+						'condition' => 'service_completed_successfully',
+					],
 				],
 				'environment' => [
 					'MC_HOST_local' => 'http://admin:password@s3:9000',
@@ -662,7 +682,7 @@ class Docker_Compose_Generator {
 				'links' => [
 					's3',
 				],
-				'entrypoint' => "/bin/sh -c \"mc mb -p local/{$this->bucket_name} && mc policy set public local/{$this->bucket_name} && mc mirror --watch --overwrite -a local/{$this->bucket_name} /content\"",
+				'entrypoint' => "/bin/sh -c \"mc mirror --watch --overwrite -a local/{$this->bucket_name} /content\"",
 			],
 		];
 	}


### PR DESCRIPTION
Our s3 healthcheck isn't sufficient to say "s3 is ready" as we also need the bucket to be created. TO do that we need to decouple the bucket creation from the current sync command, so PHP containers can have their deps met without needing to wait for syncing to complete.

This is relevant mostly when running local-server in scripted ways (like CI) as there's no wait / time between `composer server start` and `composer dev-tools phpunit` or similar types of things.

Fixes https://github.com/humanmade/altis-dev-tools/issues/845

---

## For Altis Team Use

### Completion Checklist
Does this PR meet our definition of done? See [the Play Book Definition of Done](https://playbook.hmn.md/play/product/definition-of-done-2/)

- [ ] Has the acceptance criteria been met?
- [ ] Is the documentation updated (including README)?
- [ ] Do any code/documentation changes meet project standards?
- [ ] Are automatic tests in place to verify the fix or new functionality?
    - [ ] OR, are manual tests documented (at least on the ticket/PR)?
- [ ] Are any Playbook/Handbook pages updated?
- [ ] Has a new module release (patch/minor) been created/scheduled?
- [ ] Have the appropriate `backport` labels been added to the PR?
- [ ] Is there a roll-out (and roll-back) plan, if required?
