### PR TITLE
Name and autoremove the import-uploads command's minio container

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -1111,6 +1111,7 @@ EOT;
 				'--volume=%3$s/content/uploads:/content/uploads:delegated ' .
 				'--network=%4$s_default ' .
 				'--name=%4$s-import-uploads ' .
+				'--rm ' . // Clean up container after it exits.
 				'minio/mc:RELEASE.2021-09-02T09-21-27Z %5$s',
 			$columns,
 			$lines,

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -1110,6 +1110,7 @@ EOT;
 				'-e MC_HOST_local=http://admin:password@s3:9000 ' .
 				'--volume=%3$s/content/uploads:/content/uploads:delegated ' .
 				'--network=%4$s_default ' .
+				'--name=%4$s-import-uploads ' .
 				'minio/mc:RELEASE.2021-09-02T09-21-27Z %5$s',
 			$columns,
 			$lines,


### PR DESCRIPTION
This prevents Docker from becoming littered with repeated "lovable_badger", "terrible_matsumoto", "mysterious_platypus" leftover default-name for the minio containers:
<img width="633" alt="image" src="https://github.com/user-attachments/assets/170330ab-ac0c-49e3-9762-4c2cc052a8e2" />

Changes:

- Clean up the container after Exit
- Name it based on the project domain it so that it's more easily identifiable in Docker tooling while running