### PR TITLE
Document the new logs aliases for db.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -118,7 +118,7 @@ in `composer.json`, namely the `altis.modules.local-server` tree, specifically t
       including `custom-domain.com`
   * `composer server ssl exec -- [<command>]` - Execute custom `mkcert` commands, e.g. `-uninstall` to revoke the root CA
 * `composer server logs <service>` - Tail the logs from a given service, defaults to `php`, available options
-  are `nginx`, `php`, `db`, `redis`, `cavalcade`, `tachyon`, `s3` and `elasticsearch`.
+  are `nginx`, `php`, `db|mysql|sql`, `redis`, `cavalcade`, `tachyon`, `s3` and `elasticsearch`.
 * `composer server shell` - Logs in to the PHP container.
 * `composer server cli|wp -- <command>` - Runs a WP CLI command. Use either `cli` or `wp`. For example,
   `composer server cli -- info` or `composer server wp -- info`. Do not include `wp` in `<command>`.

--- a/docs/viewing-logs.md
+++ b/docs/viewing-logs.md
@@ -2,8 +2,8 @@
 
 Often you'll want to access logs from the services that Local Server provides. For example, PHP Errors Logs, Nginx Access Logs, or
 MySQL Logs. To do so, run the `composer server logs <service>` command. `<service>` can be any
-of `php`, `nginx`, `db`, `elasticsearch`, `s3`, `xray`, `cavalcade` or `redis`. This command will tail the logs (live update). To
-exit the log view, press `Ctrl+C`.
+of `php`, `nginx`, `db|mysql|sql`, `elasticsearch`, `s3`, `xray`, `cavalcade` or `redis`. This command will tail the logs (live
+update). To exit the log view, press `Ctrl+C`.
 
 Local Server provides these commands as aliases to the underlying `docker logs` command, so you may alternatively list out running
 containers with `docker ps` and then follow the logs for any individual running container. This lets you monitor logs from any


### PR DESCRIPTION
Adds documentation for the aliases for the `composer server logs db` command.

Addresses https://github.com/humanmade/altis-local-server/issues/712