### PR TITLE
Fold Server Start output in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ before_script:
   - cd $HOME/test-root && composer require -W "$ALTIS_PACKAGE:dev-${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} as `jq \".\\\"packages-dev\\\"[] | select (.name==\\\"$ALTIS_PACKAGE\\\") | .version\" composer.lock | sed -e 's/\"//g;/^dev/q;s/\$/9/'`"
 
 script:
+  - fold_start server-start
   - cd $HOME/test-root && composer server start
+  - fold_end server-start
   - cd $HOME/test-root && composer server db info
   - cd $HOME/test-root && composer server db exec -- "select * from wp_site;"
   - cd $HOME/test-root && composer server status


### PR DESCRIPTION
Fold the output of the server start command in Travis CI to make it easier to see the output of the other commands.

Fixes: https://github.com/humanmade/altis-local-server/issues/429

Hat Tip: @szepeviktor for the PR