### PR TITLE
Fold the composer server logs output in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ before_script:
   - cd $HOME/test-root && composer require -W "$ALTIS_PACKAGE:dev-${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} as `jq \".\\\"packages-dev\\\"[] | select (.name==\\\"$ALTIS_PACKAGE\\\") | .version\" composer.lock | sed -e 's/\"//g;/^dev/q;s/\$/9/'`"
 
 script:
+  - echo -en "travis_fold:start:server_start\r"
   - cd $HOME/test-root && composer server start
+  - echo -en "travis_fold:end:server_start\r"
   - cd $HOME/test-root && composer server db info
   - cd $HOME/test-root && composer server db exec -- "select * from wp_site;"
   - cd $HOME/test-root && composer server status


### PR DESCRIPTION
This change adds fold markers around the composer server start command in the Travis CI build to make it easier to see the output of the command in the build logs.

Fixes https://github.com/humanmade/altis-local-server/issues/429

Note: These markers are not officially documented but are acknowledged by Travis contributors. For example, [here](https://github.com/travis-ci/travis-ci/issues/2285)