### PR TITLE
Update error message to be more accurate

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -315,7 +315,7 @@ EOT
 
 			// Check install was successful.
 			if ( $install_failed ) {
-				$output->writeln( sprintf( '<error>WordPress install failed. Exited with error code %d</>', $install_failed ) );
+				$output->writeln( sprintf( '<error>WordPress install failed or database unavailable. Exited with error code %d</>', $install_failed ) );
 				return $install_failed;
 			}
 


### PR DESCRIPTION
Updates the error message to show that unavailable database may also be the issue.

Fixes: https://github.com/humanmade/altis-local-server/issues/557

Output now looks like:
```
$ composer server start
Starting...
[+] Running 1/1
 ✔ Container altis-proxy  Running                                      0.0s
[+] Running 13/13
 ✔ Container altis-dev-s3                  Healthy                     1.0s
 ✔ Container altis-dev-tachyon             Running                     0.0s
 ✔ Container altis-dev-es                  Healthy                     1.7s
 ✔ Container altis-dev-redis               Running                     0.0s
 ✔ Container altis-dev-s3-create-bucket-1  Exited                      1.7s
 ✔ Container altis-dev-xray                Running                     0.0s
 ✔ Container altis-dev-kibana              Running                     0.0s
 ✔ Container altis-dev-s3-sync             Running                     0.0s
 ✔ Container altis-dev-mailhog             Running                     0.0s
 ✔ Container altis-dev-db                  Healthy                     1.7s
 ✔ Container altis-dev-cavalcade           Started                     1.9s
 ✔ Container altis-dev-nginx               Started                     2.1s
 ✔ Container altis-dev-php                 Started                     1.6s
Warning: mysqli_real_connect(): php_network_getaddresses: getaddrinfo for dbz failed: Temporary failure in name resolution in /usr/src/app/vendor/humanmade/ludicrousdb/ludicrousdb/includes/class-ludicrousdb.php on line 946
Warning: mysqli_real_connect(): (HY000/2002): php_network_getaddresses: getaddrinfo for dbz failed: Temporary failure in name resolution in /usr/src/app/vendor/humanmade/ludicrousdb/ludicrousdb/includes/class-ludicrousdb.php on line 946

WordPress install failed or database unavailable. Exited with error code 130
```
