### PR TITLE
Update container images to the latest

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -98,9 +98,9 @@ class Docker_Compose_Generator {
 	 */
 	protected function get_php_reusable() : array {
 		$version_map = [
-			'8.3' => 'humanmade/altis-local-server-php:8.3.11',
-			'8.2' => 'humanmade/altis-local-server-php:8.2.25',
-			'8.1' => 'humanmade/altis-local-server-php:6.0.22',
+			'8.3' => 'humanmade/altis-local-server-php:8.3.14',
+			'8.2' => 'humanmade/altis-local-server-php:8.2.28',
+			'8.1' => 'humanmade/altis-local-server-php:6.0.25',
 		];
 
 		$versions = array_keys( $version_map );
@@ -354,7 +354,7 @@ class Docker_Compose_Generator {
 
 		return [
 			'nginx' => [
-				'image' => 'humanmade/altis-local-server-nginx:3.5.8',
+				'image' => 'humanmade/altis-local-server-nginx:3.6.0',
 				'container_name' => "{$this->project_name}-nginx",
 				'networks' => [
 					'proxy',


### PR DESCRIPTION
- Updates container images to latest
  - PHP and Sandbox
    - [8.3.14](https://github.com/humanmade/docker-wordpress-php/releases/tag/8.3.14)  
    - [8.2.28](https://github.com/humanmade/docker-wordpress-php/releases/tag/8.2.18)  
    - [6.0.25](https://github.com/humanmade/docker-wordpress-php/releases/tag/6.0.25)
  - NGINX
    - [3.6.0](https://github.com/humanmade/docker-wordpress-nginx/releases/tag/3.6.0)
- Delievers https://github.com/humanmade/terraform-app-stack/issues/1750