### PR TITLE
Automatically roll SSL certs

### DIFF
--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -14,6 +14,7 @@ namespace Altis\Local_Server\Composer;
 
 use Composer\Command\BaseCommand;
 use Composer\Composer;
+use Exception;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -1032,7 +1033,7 @@ EOT;
 	/**
 	 * Get the SSL certificate expiration date.
 	 *
-	 * @throws Exception if openssl is missing, the certificate is invalid, or it cannot be read.
+	 * @throws Exception If openssl is missing, the certificate is invalid, or it cannot be read.
 	 * @param string $path Path to the certificate file.
 	 * @return int Days until expiry. If negative, the certificate has already expired.
 	 */


### PR DESCRIPTION
Automatically regenerates certificates on `composer server start` if they're expiring soon:
<img width="1205" height="440" alt="Screenshot 2025-09-15 at 15 22 30" src="https://github.com/user-attachments/assets/7524b6b1-809a-4eaa-9570-be803ef5afba" />

Also changes `composer server ssl` to output remaining validity days:
```
$ composer server ssl
Certificate exists and is valid for 822 more days
```

And error if it's expired.

Fixes #849.