### PR TITLE
Add support for PHP 8.4 docker image

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -107,6 +107,7 @@ class Docker_Compose_Generator {
 	 */
 	protected function get_php_reusable() : array {
 		$version_map = [
+			'8.4' => 'humanmade/altis-local-server-php:8.4.0',
 			'8.3' => 'humanmade/altis-local-server-php:8.3.14',
 			'8.2' => 'humanmade/altis-local-server-php:8.2.28',
 			'8.1' => 'humanmade/altis-local-server-php:6.0.25',


### PR DESCRIPTION
Add support for PHP 8.4 docker image.
Note this depends on PR https://github.com/humanmade/docker-wordpress-php/pull/400

- Addresses https://github.com/humanmade/product-dev/issues/1836
