### PR TITLE
Update PHP versions to latest Docker tags.

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -107,10 +107,10 @@ class Docker_Compose_Generator {
 	 */
 	protected function get_php_reusable() : array {
 		$version_map = [
-			'8.4' => 'humanmade/altis-local-server-php:8.4.0',
-			'8.3' => 'humanmade/altis-local-server-php:8.3.14',
-			'8.2' => 'humanmade/altis-local-server-php:8.2.28',
-			'8.1' => 'humanmade/altis-local-server-php:6.0.25',
+			'8.4' => 'humanmade/altis-local-server-php:8.4.2',
+			'8.3' => 'humanmade/altis-local-server-php:8.3.17',
+			'8.2' => 'humanmade/altis-local-server-php:8.2.31',
+			'8.1' => 'humanmade/altis-local-server-php:6.0.27',
 		];
 
 		$versions = array_keys( $version_map );


### PR DESCRIPTION
Update PHP versions to latest Docker tags.

- '8.4' from 8.4.0 to 8.4.2
- '8.3' from 8.3.14 to 8.3.17
- '8.2' from 8.2.28 to 8.2.31
- '8.1' from 6.0.25 to 6.0.27
