### PR TITLE
Minimum should still be 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"require": {
-		"php": ">=8.3",
+		"php": ">=8.2",
 		"composer-plugin-api": "^1.1 || ^2.0",
 		"symfony/yaml": "~6.3.12",
 		"symfony/console": "^5.4.24"


### PR DESCRIPTION
In trying to default to 8.3 I inadvertently set the minimum version to 8.3
