### PR TITLE
Update Dependabot to remove v21 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,12 +44,3 @@ updates:
   - dependency-type: "direct"
   versioning-strategy: "increase"
   target-branch: v22-branch
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-  allow:
-  - dependency-type: "direct"
-  versioning-strategy: "increase"
-  target-branch: v21-branch


### PR DESCRIPTION

This PR updates Dependabot configuration to remove the v21 branch.