### PR TITLE
Update PHP Docker container versions

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -107,9 +107,9 @@ class Docker_Compose_Generator {
 	 */
 	protected function get_php_reusable() : array {
 		$version_map = [
-			'8.4' => 'humanmade/altis-local-server-php:8.4.3',
-			'8.3' => 'humanmade/altis-local-server-php:8.3.18',
-			'8.2' => 'humanmade/altis-local-server-php:8.2.32',
+			'8.4' => 'humanmade/altis-local-server-php:8.4.4',
+			'8.3' => 'humanmade/altis-local-server-php:8.3.19',
+			'8.2' => 'humanmade/altis-local-server-php:8.2.33',
 			'8.1' => 'humanmade/altis-local-server-php:6.0.27',
 		];
 


### PR DESCRIPTION
Update PHP versions to latest Docker tags.

    '8.4' from 8.4.2 to 8.4.3
    '8.3' from 8.3.17 to 8.3.18
    '8.2' from 8.2.31 to 8.2.32

