### PR TITLE
[Backport v22-branch] Bump PHP images for Afterburner

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -98,9 +98,9 @@ class Docker_Compose_Generator {
 	 */
 	protected function get_php_reusable() : array {
 		$version_map = [
-			'8.3' => 'humanmade/altis-local-server-php:8.3.19',
-			'8.2' => 'humanmade/altis-local-server-php:8.2.33',
-			'8.1' => 'humanmade/altis-local-server-php:6.0.27',
+			'8.3' => 'humanmade/altis-local-server-php:8.3.23',
+			'8.2' => 'humanmade/altis-local-server-php:8.2.36',
+			'8.1' => 'humanmade/altis-local-server-php:6.0.30',
 		];
 
 		$versions = array_keys( $version_map );


### PR DESCRIPTION
Backport of #887 to `v22-branch`.