### PR TITLE
Add MySQL 8.4 support

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -2,7 +2,26 @@
 
 ## Available Versions
 
-Altis supports MySQL version `8.0`.
+Altis supports MySQL versions `8.4` and `8.0`.
+The default version is `8.0`.
+
+To change the MySQL version use the Local Server module configuration to set the `mysql` property:
+
+```json
+{
+    "extra": {
+        "altis": {
+            "modules": {
+                "local-server": {
+                    "mysql": "8.4"
+                }
+            }
+        }
+    }
+}
+```
+
+**Note**: Only the major and minor versions (x.y) should be specified.
 
 ## Interacting with the Database
 

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -450,6 +450,7 @@ class Docker_Compose_Generator {
 	 */
 	protected function get_service_db() : array {
 		$version_map = [
+			'8.4' => 'mysql:8.4.6',
 			'8.0' => 'mysql:8.0.44',
 		];
 


### PR DESCRIPTION
Delivers https://github.com/humanmade/altis-local-server/issues/895

- Matches the version we use in AWS: MySQL 8.4.6
- Defaults to 8.0 unless specified in composer.json