### PR TITLE
Support private uploads: add TACHYON_SERVER_VERSION

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -586,9 +586,7 @@ class Docker_Compose_Generator {
 					'/bin/sh',
 					'-c',
 					sprintf(
-						"aws s3api create-bucket --bucket %s --endpoint-url=http://s3:7070 || true; aws s3api put-bucket-policy --bucket %s --policy '{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"PublicReadUploads\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":[\"s3:GetObject\"],\"Resource\":[\"arn:aws:s3:::%s/uploads/*\"]}]}' --endpoint-url=http://s3:7070 || true",
-						$this->bucket_name,
-						$this->bucket_name,
+						"aws s3api create-bucket --bucket %s --endpoint-url=http://s3:7070 || true",
 						$this->bucket_name
 					),
 				],

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -586,7 +586,9 @@ class Docker_Compose_Generator {
 					'/bin/sh',
 					'-c',
 					sprintf(
-						"aws s3api create-bucket --bucket %s --endpoint-url=http://s3:7070 || true",
+						"aws s3api create-bucket --bucket %s --endpoint-url=http://s3:7070 || true; aws s3api put-bucket-policy --bucket %s --policy '{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"PublicReadUploads\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":[\"s3:GetObject\"],\"Resource\":[\"arn:aws:s3:::%s/uploads/*\"]}]}' --endpoint-url=http://s3:7070 || true",
+						$this->bucket_name,
+						$this->bucket_name,
 						$this->bucket_name
 					),
 				],

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -67,6 +67,11 @@ function bootstrap() {
 	if ( $config['tachyon'] ?? true ) {
 		define( 'TACHYON_URL', getenv( 'TACHYON_URL' ) );
 
+		// Local Tachyon image is v3.0.7+, which supports presigned URL passthrough.
+		if ( ! defined( 'TACHYON_SERVER_VERSION' ) ) {
+			define( 'TACHYON_SERVER_VERSION', '3.0.0' );
+		}
+
 		/**
 		 * In local-server, the tachyon hostname resolves to what is deemed a local url.
 		 * This makes requests to tachyon from WordPress disallowed. We want to


### PR DESCRIPTION
## Summary

- Define `TACHYON_SERVER_VERSION` constant (`3.0.0`) when Tachyon is enabled, enabling presigned URL passthrough for private media

## Context

This change supports the default-private uploads feature in the media module. The local Tachyon image (v3.0.7+) supports presigned URL passthrough, but the constant was not being set in local-server.

Ref: https://github.com/humanmade/altis-media/issues/162

🤖 Generated with [Claude Code](https://claude.com/claude-code)