### PR TITLE
Fix cases where `$PWD` is empty in `Process()`

### DIFF
--- a/docker/proxy.yml
+++ b/docker/proxy.yml
@@ -6,10 +6,10 @@ services:
     container_name: altis-proxy
     mem_limit: 128m
     volumes:
-      - "$PWD/altis/local-server/docker/conf/traefik.toml:/etc/traefik/traefik.toml"
-      - "$PWD/altis/local-server/docker/conf/dynamic.toml:/etc/traefik/dynamic.toml"
-      - "$PWD/ssl-cert.pem:/etc/traefik/ssl-cert.pem"
-      - "$PWD/ssl-key.pem:/etc/traefik/ssl-key.pem"
+      - "$PWD/vendor/altis/local-server/docker/conf/traefik.toml:/etc/traefik/traefik.toml"
+      - "$PWD/vendor/altis/local-server/docker/conf/dynamic.toml:/etc/traefik/dynamic.toml"
+      - "$PWD/vendor/ssl-cert.pem:/etc/traefik/ssl-cert.pem"
+      - "$PWD/vendor/ssl-key.pem:/etc/traefik/ssl-key.pem"
       - /var/run/docker.sock:/var/run/docker.sock
     ports:
       - '8080:8080'

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -304,7 +304,7 @@ EOT
 		// Save a reference to the host for later runs.
 		file_put_contents( 'vendor/host', "$name.$tld" );
 
-		$proxy = $this->process( $this->get_compose_command( '-f altis/local-server/docker/proxy.yml up -d' ), 'vendor' );
+		$proxy = $this->process( $this->get_compose_command( '-f vendor/altis/local-server/docker/proxy.yml up -d' ) );
 		$proxy->setTimeout( 0 );
 		$proxy->setTty( posix_isatty( STDOUT ) );
 		$proxy_failed = $proxy->run( function ( $type, $buffer ) {
@@ -411,7 +411,7 @@ EOT
 
 		if ( $service === '' && $input->hasParameterOption( '--clean' ) ) {
 			$output->writeln( '<info>Stopping proxy container...</>' );
-			$proxy = $this->process( $this->get_compose_command( '-f proxy.yml stop' ), 'vendor/altis/local-server/docker' );
+			$proxy = $this->process( $this->get_compose_command( '-f vendor/altis/local-server/docker/proxy.yml stop' ) );
 			$proxy->setTimeout( 0 );
 			$proxy->setTty( posix_isatty( STDOUT ) );
 			$proxy->run( function ( $type, $buffer ) {
@@ -461,7 +461,7 @@ EOT
 
 		if ( $remove_proxy ) {
 			$output->writeln( '<error>Destroying proxy container...</>' );
-			$proxy = $this->process( $this->get_compose_command( '-f proxy.yml down -v' ), 'vendor/altis/local-server/docker' );
+			$proxy = $this->process( $this->get_compose_command( '-f vendor/altis/local-server/docker/proxy.yml down -v' ) );
 			$proxy->setTty( posix_isatty( STDOUT ) );
 			$proxy->run( function ( $type, $buffer ) {
 				echo $buffer;
@@ -492,7 +492,7 @@ EOT
 	protected function restart( InputInterface $input, OutputInterface $output ) {
 		$output->writeln( '<info>Restarting...</>' );
 
-		$proxy = $this->process( $this->get_compose_command( '-f proxy.yml restart' ), 'vendor/altis/local-server/docker' );
+		$proxy = $this->process( $this->get_compose_command( '-f vendor/altis/local-server/docker/proxy.yml restart' ) );
 		$proxy->setTty( posix_isatty( STDOUT ) );
 		$proxy->run( function ( $type, $buffer ) {
 			echo $buffer;
@@ -961,7 +961,7 @@ EOT;
 				exec( 'docker ps | grep altis-proxy', $result );
 				if ( $result ) {
 					$output->writeln( '<info>Restarting proxy server to activate the new certificate...</info>' );
-					$proxy = $this->process( $this->get_compose_command( '-f proxy.yml restart' ), 'vendor/altis/local-server/docker' );
+					$proxy = $this->process( $this->get_compose_command( '-f vendor/altis/local-server/docker/proxy.yml restart' ) );
 					$proxy->setTty( posix_isatty( STDOUT ) );
 					$proxy->run( function ( $type, $buffer ) {
 						echo $buffer;


### PR DESCRIPTION
## Describe the PR 
<!-- 
- Make sure the title is clear and concise.
- Include the purpose of this PR.
- Include a brief description of the what and why of this change.
- Include a link to a GH issue, if relevant.
- Fixes #<issue_number_or_url> will close the issue whjen this is merged
- Addresses #<issue_number_or_url> will link the issue to this PR
- Are there any specific things you want a reviewer to notice/check/give feedback?
-->

I haven't managed to ascertain exactly why but the value of `$PWD` in the proxy.yml file was not resolving correctly in an Altis v25 project. I couldn't find anything specific about a change in behaviour in this regard, but these changes seem to make it more consistent and robust.

The error was that the volume mounts were failing, creating empty directories for the `.toml` file, and certificate files in the project root, rather than based from `vendor`, despite it being set as the 2nd param to `new Process()`.

---

## For Altis Team Use

### Completion Checklist
Does this PR meet our definition of done? See [the Play Book Definition of Done](https://playbook.hmn.md/play/product/definition-of-done-2/)

- [ ] Has the acceptance criteria been met?
- [ ] Is the documentation updated (including README)?
- [ ] Do any code/documentation changes meet project standards?
- [ ] Are automatic tests in place to verify the fix or new functionality?
    - [ ] OR, are manual tests documented (at least on the ticket/PR)?
- [ ] Are any Playbook/Handbook pages updated?
- [ ] Has a new module release (patch/minor) been created/scheduled?
- [ ] Have the appropriate `backport` labels been added to the PR?
- [ ] Is there a roll-out (and roll-back) plan, if required?
