### PR TITLE
Replacing Redis container with Valkey

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -434,7 +434,7 @@ class Docker_Compose_Generator {
 	protected function get_service_redis() : array {
 		return $this->apply_service_defaults( [
 			'redis' => [
-				'image' => 'redis:7.0-alpine',
+				'image' => 'valkey/valkey:7.2.6-alpine',
 				'container_name' => "{$this->project_name}-redis",
 				'ports' => [
 					'6379',


### PR DESCRIPTION
- Delivers https://github.com/humanmade/product-dev/issues/2002

Replace Redis container with Valkey container with version 7.2.6 to be on pair with AWS Valkey version 