### PR TITLE
Update Traefik image to latest

### DIFF
--- a/docker/proxy.yml
+++ b/docker/proxy.yml
@@ -2,7 +2,7 @@ services:
   proxy:
     networks:
       - proxy
-    image: traefik:3.6.6
+    image: traefik:3.6.12
     container_name: altis-proxy
     mem_limit: 128m
     volumes:


### PR DESCRIPTION
This PR updates the Traefik proxy image to the latest tagged version.

Fixes https://github.com/humanmade/altis-local-server/issues/905
