### PR TITLE
Allow passing MySQL args through composer server db

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -122,6 +122,7 @@ in `composer.json`, namely the `altis.modules.local-server` tree, specifically t
 - `composer server create-alias` - Create a WP CLI alias. Useful if you have WP CLI installed locally.
 - `composer server exec -- <command>` - Runs any command on the PHP container.
 - `composer server db` - Logs into MySQL on the DB container.
+  - `composer server db -- -A` - Pass arguments directly to the MySQL client.
   - `composer server db info` - Print MySQL connection details.
   - `composer server db (sequel|spf)` - Opens a connection to the database in [Sequel Ace](https://sequel-ace.com/).
   - `composer server db (tableplus|tbp)` - Opens a connection to the database in [Table Plus](https://tableplus.com/).

--- a/docs/database.md
+++ b/docs/database.md
@@ -31,6 +31,12 @@ You can log into MySQL and run any query in the default database (`wordpress`) b
 composer server db
 ```
 
+Pass extra arguments through to the MySQL client by separating them with `--`:
+
+```sh
+composer server db -- -A
+```
+
 Use `composer server db info` to retrieve MySQL info and connection details:
 
 ```sh

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -80,7 +80,7 @@ Open a shell:
 	shell                         Open a Bash shell as the www-data user.
 	shell --root|-r               Open a Bash shell as the root user.
 Database commands:
-	db                            Log into MySQL on the Database server
+	db [-- <args>]                Log into MySQL on the Database server, with optional mysql args
 	db (sequel|spf)               Opens Sequel Pro/Sequel Ace with the database connection
 	db (tableplus|tbp)            Opens TablePlus with the database connection
 	db info                       Prints out Database connection details
@@ -695,7 +695,8 @@ EOT
 	 * @return int
 	 */
 	protected function db( InputInterface $input, OutputInterface $output ) {
-		$db = $input->getArgument( 'options' )[0] ?? null;
+		$options = $input->getArgument( 'options' ) ?? [];
+		$db = $options[0] ?? null;
 		$columns = exec( 'tput cols' );
 		$lines = exec( 'tput lines' );
 
@@ -776,7 +777,6 @@ EOT;
 				break;
 
 			case 'exec':
-				$options = $input->getArgument( 'options' ) ?? [];
 				// Remove the subcommand, we don't need it.
 				array_shift( $options );
 				// The query is always the last option.
@@ -796,13 +796,16 @@ EOT;
 				break;
 
 			case null:
-				// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
-				passthru( "$base_command mysql --database=wordpress --user=root", $return_val );
-				break;
-
 			default:
-				$output->writeln( "<error>The subcommand $db is not recognized</error>" );
-				$return_val = 1;
+				if ( $db !== null && strpos( $db, '-' ) !== 0 ) {
+					$output->writeln( "<error>The subcommand $db is not recognized</error>" );
+					$return_val = 1;
+					break;
+				}
+
+				$args = count( $options ) > 0 ? ' ' . implode( ' ', array_map( 'escapeshellarg', $options ) ) : '';
+				// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
+				passthru( "$base_command mysql --database=wordpress --user=root$args", $return_val );
 		}
 
 		return $return_val;


### PR DESCRIPTION
## Describe the PR

This lets `composer server db` pass extra MySQL client arguments through to the `mysql` command instead of treating the first extra token as an internal Local Server subcommand.

That means commands like:

- `composer server db -- -A`
- `composer server db -- --skip-column-names`

now work as expected.

Also updates the command help and docs to show the passthrough usage.

Manual testing:
- Not run in-container here; validated the command-path change and updated docs.

---

## For Altis Team Use

### Completion Checklist
Does this PR meet our definition of done? See [the Play Book Definition of Done](https://playbook.hmn.md/play/product/definition-of-done-2/)

- [x] Has the acceptance criteria been met?
- [x] Is the documentation updated (including README)?
- [x] Do any code/documentation changes meet project standards?
- [ ] Are automatic tests in place to verify the fix or new functionality?
    - [x] OR, are manual tests documented (at least on the ticket/PR)?
- [ ] Are any Playbook/Handbook pages updated?
- [ ] Has a new module release (patch/minor) been created/scheduled?
- [ ] Have the appropriate `backport` labels been added to the PR?
- [ ] Is there a roll-out (and roll-back) plan, if required?
