### PR TITLE
Don't require a TTY for non-interactive composer server commands

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -52,6 +52,21 @@ composer server cli -- language core install fr_FR
 
 CLI commands via Local Server also support piping for more complex shell commands.
 
+## Running without a terminal (CI, scripts, cron, agents)
+
+Most `composer server` subcommands run fine without an attached terminal:
+
+- `composer server cli|wp|exec -- <command>`
+- `composer server db exec -- "<sql>"`
+- `composer server db -- -e "<sql>"` (any args that include `-e`/`--execute`/`-B`)
+- `composer server s3 import-uploads`, `composer server s3 ls`, `composer server s3 exec -- <args>`
+- `composer server logs <service>`
+- `composer server start`, `stop`, `restart`, `status`, `ssl …`
+
+The interactive subcommands — `composer server shell`, the `composer server db` REPL, and the `composer server logs` service picker — require an attached terminal. When run without one (e.g. CI, cron, ssh without `-t`, an editor task, or an AI agent) they exit immediately with a clear error suggesting a non-interactive alternative, instead of hanging on a prompt or failing on Docker's TTY error.
+
+`composer server destroy` still prompts for confirmation. Without a TTY the prompt's default (no) is taken, so the command becomes a silent no-op — pass `--no-interaction` explicitly when scripting if you want the same behaviour without the spurious prompt attempt.
+
 ### Importing a database backup
 
 To import a database backup with local server, you will need to have a database backup file in a location that is accessible from

--- a/docs/database.md
+++ b/docs/database.md
@@ -64,3 +64,8 @@ Use `composer server db exec -- "<command>"` to execute and output the results o
 ```sh
 composer server db exec -- 'select id,post_title from wordpress.wp_posts limit 2;'
 ```
+
+`db exec` is safe to run from scripts, CI, cron, and other non-interactive
+contexts — it does not require a controlling terminal. The interactive
+`composer server db` REPL does require a terminal and will exit with a clear
+message when one is not attached.

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -618,6 +618,9 @@ EOT
 	 */
 	protected function logs( InputInterface $input, OutputInterface $output ) {
 		if ( ! isset( $input->getArgument( 'options' )[0] ) ) {
+			if ( ! $this->require_tty( $output, 'composer server logs', 'composer server logs <service>  (e.g. php, db, nginx, elasticsearch)' ) ) {
+				return 1;
+			}
 			$helper = $this->getHelper( 'question' );
 			$question = new ChoiceQuestion(
 				'Please select a service (defaults to php)',
@@ -660,6 +663,10 @@ EOT
 	 * @return int
 	 */
 	protected function shell( InputInterface $input, OutputInterface $output ) {
+		if ( ! $this->require_tty( $output, 'composer server shell', 'composer server exec -- <command>' ) ) {
+			return 1;
+		}
+
 		$columns = exec( 'tput cols' );
 		$lines = exec( 'tput lines' );
 		$command_prefix = $this->get_base_command_prefix();
@@ -700,13 +707,20 @@ EOT
 		$columns = exec( 'tput cols' );
 		$lines = exec( 'tput lines' );
 
-		$base_command = sprintf(
-			// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
-			'docker exec -it -u root -e COLUMNS=%d -e LINES=%d -e MYSQL_PWD=wordpress %s-db',
-			$columns,
-			$lines,
-			$this->get_project_subdomain()
-		);
+		// Build the docker exec base command. Pass `-it` only for the
+		// interactive REPL; non-interactive paths (`db exec`) use `-i` so they
+		// work in scripts, CI, cron, and other no-TTY contexts.
+		$build_base_command = function ( bool $interactive ) use ( $columns, $lines ) : string {
+			$flags = $interactive ? '-it' : '-i';
+			return sprintf(
+				// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
+				'docker exec %s -u root -e COLUMNS=%d -e LINES=%d -e MYSQL_PWD=wordpress %s-db',
+				$flags,
+				$columns,
+				$lines,
+				$this->get_project_subdomain()
+			);
+		};
 
 		$return_val = 0;
 
@@ -791,6 +805,7 @@ EOT;
 				if ( substr( $query, -1 ) !== ';' ) {
 					$query = "$query;";
 				}
+				$base_command = $build_base_command( false );
 				// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
 				passthru( "$base_command mysql --database=wordpress --user=root $args -e \"$query\"", $return_val );
 				break;
@@ -803,6 +818,27 @@ EOT;
 					break;
 				}
 
+				// mysql exits immediately for `-e <query>` / `--execute=<query>`
+				// and `-B` / `--batch`; everything else opens the interactive
+				// REPL. Treat the former as non-interactive so they work in
+				// scripts, CI, cron, and other no-TTY contexts.
+				$is_non_interactive = false;
+				foreach ( $options as $opt ) {
+					if (
+						$opt === '-e' || $opt === '--execute'
+						|| $opt === '-B' || $opt === '--batch'
+						|| strpos( $opt, '--execute=' ) === 0
+					) {
+						$is_non_interactive = true;
+						break;
+					}
+				}
+
+				if ( ! $is_non_interactive && ! $this->require_tty( $output, 'composer server db', 'composer server db exec -- "<query>", or pass -e "<query>" through with --' ) ) {
+					return 1;
+				}
+
+				$base_command = $build_base_command( ! $is_non_interactive );
 				$args = count( $options ) > 0 ? ' ' . implode( ' ', array_map( 'escapeshellarg', $options ) ) : '';
 				// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
 				passthru( "$base_command mysql --database=wordpress --user=root$args", $return_val );
@@ -1249,6 +1285,41 @@ EOT;
 	}
 
 	/**
+	 * Check whether the current process is attached to an interactive terminal.
+	 *
+	 * @return boolean
+	 */
+	public static function is_tty() : bool {
+		return function_exists( 'posix_isatty' )
+			&& posix_isatty( STDIN )
+			&& posix_isatty( STDOUT );
+	}
+
+	/**
+	 * Gate a command on the presence of an interactive terminal.
+	 *
+	 * Prints a friendly error and returns false when no TTY is attached, so
+	 * scripted/CI/agent callers get a clear message instead of an opaque
+	 * failure from Docker (or a hung prompt).
+	 *
+	 * @param OutputInterface $output      Command output object.
+	 * @param string          $command     Full command label, e.g. 'composer server shell'.
+	 * @param string|null     $alternative Optional non-interactive alternative to suggest.
+	 * @return boolean True when a TTY is available; false otherwise.
+	 */
+	protected function require_tty( OutputInterface $output, string $command, ?string $alternative = null ) : bool {
+		if ( self::is_tty() ) {
+			return true;
+		}
+
+		$output->writeln( "<error>`$command` requires an interactive terminal.</>" );
+		if ( $alternative ) {
+			$output->writeln( "<info>For non-interactive use, try: $alternative</>" );
+		}
+		return false;
+	}
+
+	/**
 	 * Check if the current host operating system is Mac OS.
 	 *
 	 * @return boolean
@@ -1453,9 +1524,10 @@ EOT
 
 		$columns = exec( 'tput cols 2>/dev/null' ) ?: 120;
 		$lines = exec( 'tput lines 2>/dev/null' ) ?: 40;
+		$tty_flag = self::is_tty() ? '-it' : '-i';
 
 		$command = sprintf(
-			'docker run --rm -it ' .
+			'docker run --rm %s ' .
 				'-e COLUMNS=%d -e LINES=%d ' .
 				'-e AWS_ACCESS_KEY_ID=admin ' .
 				'-e AWS_SECRET_ACCESS_KEY=password ' .
@@ -1464,6 +1536,7 @@ EOT
 				'--network=%s_default ' .
 				'amazon/aws-cli:2.31.0 ' .
 				's3 sync /content/uploads s3://%s/uploads --endpoint-url=http://s3:7070',
+			$tty_flag,
 			$columns,
 			$lines,
 			escapeshellarg( getcwd() ),
@@ -1528,9 +1601,10 @@ EOT
 
 		$columns = exec( 'tput cols 2>/dev/null' ) ?: 120;
 		$lines = exec( 'tput lines 2>/dev/null' ) ?: 40;
+		$tty_flag = self::is_tty() ? '-it' : '-i';
 
 		$command = sprintf(
-			'docker run --rm -it ' .
+			'docker run --rm %s ' .
 				'-e COLUMNS=%d -e LINES=%d ' .
 				'-e AWS_ACCESS_KEY_ID=admin ' .
 				'-e AWS_SECRET_ACCESS_KEY=password ' .
@@ -1538,6 +1612,7 @@ EOT
 				'--network=%s_default ' .
 				'amazon/aws-cli:2.31.0 ' .
 				'--endpoint-url=http://s3:7070 %s',
+			$tty_flag,
 			$columns,
 			$lines,
 			escapeshellarg( $project_name ),


### PR DESCRIPTION


`composer server db exec`, `composer server s3 import-uploads`, and
`composer server s3 exec` always passed `docker exec/run -it`. The `-t`
forces Docker to allocate a pseudo-TTY, which fails with

> cannot attach stdin to a TTY-enabled container because stdin is not a terminal

whenever the caller has no controlling terminal. That breaks GitHub
Actions, cron, plain shell scripts, `ssh host "composer server …"`
without `ssh -t`, docker-in-docker runners, AI/dev-agent tooling
(Claude Code, Cursor, Aider, Continue), and — most directly for our
team — the test-database creation step inside `composer dev-tools
codecept run`, which delegates SQL setup to `composer server db exec`.

This PR drops `-t` from the paths that don't need it and gates the
genuinely interactive paths on a friendly TTY check.

### What changed

`inc/composer/class-command.php`:

- Added `is_tty()` and `require_tty()` helpers.
- `db()` now builds its `docker exec` base command per case, with `-it`
  for the REPL and `-i` for one-shot queries.
- `db exec`: drops `-t`, runs anywhere stdin is available.
- `db -- <args>` (PR #915 passthrough): if the args contain
  `-e`/`--execute`/`-B`/`--batch` the call is treated as
  non-interactive (`-i`); otherwise it gates on `require_tty()` because
  it would open the REPL.
- `db` with no args (REPL): gates on `require_tty()`.
- `shell`: gates on `require_tty()`.
- `logs` with no service: gates on `require_tty()` (the picker is
  Symfony `ChoiceQuestion`, useless without a terminal).
- `s3 import-uploads`, `s3 exec`: TTY flag is now `-it` only when a TTY
  is attached, otherwise `-i`.
- `destroy` is left as-is: the existing `ConfirmationQuestion` already
  short-circuits to `false` when `--no-interaction` is set (which our
  Travis config does via `COMPOSER_NO_INTERACTION=1`), so adding a
  hard TTY gate would have regressed CI for a working-by-accident path.

`docs/cli.md`, `docs/database.md`: new section listing which
subcommands are headless-safe and which require a terminal, with the
non-interactive alternatives the gate suggests at runtime.

No CI changes were needed — the per-package `.travis.yml`,
`scripts/nightly-tests.sh`, and the imported
`humanmade/altis-dev-tools:travis/module.yml` don't contain any TTY
workarounds. They worked previously because Travis allocates a pty;
they keep working with this change.

### Why

The hardcoded `-it` was the kind of bug that's invisible on the
infrastructure where it was developed (Travis, a developer's local
laptop) and lethal on the infrastructure where it isn't (anything
without a controlling terminal). Splitting the interactive and
non-interactive paths fixes the broken cases without changing the
working ones.

## Manual testing

All testing was performed against a running local stack from a
no-TTY shell (Claude Code, in this case — same TTY-less profile as
GitHub Actions, cron, etc.):

| Command | Result |
| --- | --- |
| `composer server db info` | ✅ prints connection details |
| `composer server db exec -- "SELECT VERSION(); "` | ✅ returns `8.0.44` |
| `composer server db exec -- "SELECT NOW(); "` | ✅ returns timestamp |
| `composer server db -- -e "SELECT 1+1 AS x; "` | ✅ returns `2` |
| `composer server db -- -A -e "SELECT 'pass' AS r; "` | ✅ returns `pass` (combines flags + `-e`) |
| `composer server db` (REPL) | ✅ friendly error suggesting `db exec --` |
| `composer server db -- -A` (REPL with passthrough) | ✅ friendly error, same suggestion |
| `composer server shell` | ✅ friendly error suggesting `exec --` |
| `composer server logs` (no service) | ✅ friendly error suggesting a service name |
| `composer server logs db` | ✅ streams db logs |
| `composer server s3 ls` | ✅ lists bucket contents |
| `composer server s3 exec -- s3 ls` | ✅ lists buckets via AWS CLI |
| `composer server db badcommand` | ✅ still rejected with the existing message |

`php -l` clean on `inc/composer/class-command.php`.

## Reviewer suggestions

The interactive paths can only really be confirmed from a real
terminal, so the most valuable thing a reviewer can do is run them
and confirm nothing has regressed:

1. From a normal terminal, run `composer server shell` and
   `composer server db` — both should still drop you into bash and
   the mysql REPL respectively, exactly as before.
2. From the same terminal, run `composer server db -- -A` and
   `composer server db -- --skip-column-names` — these should open
   the REPL with the flag applied (validates the
   `require_tty()`-passes branch of the new passthrough logic).
3. From a non-interactive context (e.g. `bash -c 'composer server db
   exec -- "SELECT 1; " < /dev/null'`, or any CI runner) confirm the
   exec/passthrough paths now succeed.
4. Run `composer dev-tools codecept run -p vendor/altis/<any>/tests`
   from a non-interactive shell — this exercises the
   `create_test_db()` chain that delegates SQL to
   `composer server db exec`. It should now create the test DBs
   instead of failing with the "cannot attach stdin to a TTY" error.
5. Sanity-check `composer server destroy --clean` on Travis (or with
   `COMPOSER_NO_INTERACTION=1`) — should still exit 0 silently as
   before.

Two small judgement calls worth a second pair of eyes:

- The mysql non-interactive detection only matches `-e`,
  `--execute`, `-B`, `--batch`, and `--execute=…`. Anything else
  starting with `-` is assumed interactive. Edge case: `--help`
  and `--version` exit immediately without needing a TTY, but
  they're rare enough at this seam that requiring a terminal for
  them seems fine. Easy to extend if it bites.
- `destroy` deliberately keeps its current behaviour rather than
  growing a `--yes`/`-y` flag; that felt out of scope. Happy to
  add it as a follow-up if the team prefers.

---

## For Altis Team Use

### Completion Checklist
Does this PR meet our definition of done? See [the Play Book Definition of Done](https://playbook.hmn.md/play/product/definition-of-done-2/)

- [x] Has the acceptance criteria been met?
- [x] Is the documentation updated (including README)?
- [x] Do any code/documentation changes meet project standards?
- [ ] Are automatic tests in place to verify the fix or new functionality?
    - [x] OR, are manual tests documented (at least on the ticket/PR)?
- [ ] Are any Playbook/Handbook pages updated?
- [ ] Has a new module release (patch/minor) been created/scheduled?
- [ ] Have the appropriate `backport` labels been added to the PR?
- [ ] Is there a roll-out (and roll-back) plan, if required?

🤖 Generated with [Claude Code](https://claude.com/claude-code)