### PR TITLE
Restore handling for subdomain multisites following Traefik 3 upgrade

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -900,13 +900,13 @@ class Docker_Compose_Generator {
 	protected function get_primary_host_rule( array $extra_domains = [] ) : string {
 		$host_rules = [
 			"Host(`{$this->hostname}`)",
-			"HostRegexp(`{subdomain:[A-Za-z0-9-]+}.{$this->hostname}`)",
+			'HostRegexp(`^[A-Za-z0-9-]+\\.' . str_replace( '.', '\\.', $this->hostname ) . '$`)',
 		];
 
 		$extra_domains = array_filter( array_map( 'trim', $extra_domains ) );
 		foreach ( $extra_domains as $domain ) {
 			$host_rules[] = "Host(`{$domain}`)";
-			$host_rules[] = "HostRegexp(`{subdomain:[A-Za-z0-9-]+}.{$domain}`)";
+			$host_rules[] = 'HostRegexp(`^[A-Za-z0-9-]+\\.' . str_replace( '.', '\\.', $domain ) . '$`)';
 		}
 
 		return '(' . implode( ' || ', array_unique( $host_rules ) ) . ')';
@@ -920,7 +920,7 @@ class Docker_Compose_Generator {
 	protected function get_s3_client_host_rule() : string {
 		$client_hosts = [
 			"Host(`{$this->hostname}`)",
-			"HostRegexp(`{subdomain:[A-Za-z0-9-]+}.{$this->hostname}`)",
+			'HostRegexp(`^[A-Za-z0-9-]+\\.' . str_replace( '.', '\\.', $this->hostname ) . '$`)',
 			"Host(`s3-{$this->hostname}`)",
 			'Host(`localhost`)',
 			"Host(`s3-{$this->project_name}.localhost`)",


### PR DESCRIPTION
After the upgrade to Traefik 3 yesterday in 26.0.5, my subdomains in a multisite network running on Local Server stopped resolving.

The active routing rule on the nginx container is,

```
(Host(`<name>.altis.dev`) || HostRegexp(`{subdomain:[A-Za-z0-9-]+}.<name>.altis.dev`))
```

The `HostRegexp(...)` part uses Traefik v2's named capture group syntax. In Traefik v3, `HostRegexp` apparently takes a plain Go regular expression. Go's RE2 engine treats `{subdomain:...}` as literal characters (not a named group), so that pattern never matches `<subdomain>.<name>.altis.dev`. The Host(...) clause still matches `<name>.altis.dev` exactly, which is why only the root site works.

Note: I usually still have to set `127.0.0.1 subdomain.name.altis.dev` in my etc hostfile to get subdomains to resolve, but they do work since our prior wildcard cert improvements.