### PR TITLE
Backport #916 to v25-branch: Don't require a TTY for non-interactive composer server commands

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -52,6 +52,21 @@ composer server cli -- language core install fr_FR
 
 CLI commands via Local Server also support piping for more complex shell commands.
 
+## Running without a terminal (CI, scripts, cron, agents)
+
+Most `composer server` subcommands run fine without an attached terminal:
+
+- `composer server cli|wp|exec -- <command>`
+- `composer server db exec -- "<sql>"`
+- `composer server db -- -e "<sql>"` (any args that include `-e`/`--execute`/`-B`)
+- `composer server s3 import-uploads`, `composer server s3 ls`, `composer server s3 exec -- <args>`
+- `composer server logs <service>`
+- `composer server start`, `stop`, `restart`, `status`, `ssl …`
+
+The interactive subcommands — `composer server shell`, the `composer server db` REPL, and the `composer server logs` service picker — require an attached terminal. When run without one (e.g. CI, cron, ssh without `-t`, an editor task, or an AI agent) they exit immediately with a clear error suggesting a non-interactive alternative, instead of hanging on a prompt or failing on Docker's TTY error.
+
+`composer server destroy` still prompts for confirmation. Without a TTY the prompt's default (no) is taken, so the command becomes a silent no-op — pass `--no-interaction` explicitly when scripting if you want the same behaviour without the spurious prompt attempt.
+
 ### Importing a database backup
 
 To import a database backup with local server, you will need to have a database backup file in a location that is accessible from

--- a/docs/database.md
+++ b/docs/database.md
@@ -58,3 +58,8 @@ Use `composer server db exec -- "<command>"` to execute and output the results o
 ```sh
 composer server db exec -- 'select id,post_title from wordpress.wp_posts limit 2;'
 ```
+
+`db exec` is safe to run from scripts, CI, cron, and other non-interactive
+contexts — it does not require a controlling terminal. The interactive
+`composer server db` REPL does require a terminal and will exit with a clear
+message when one is not attached.

--- a/inc/composer/class-command.php
+++ b/inc/composer/class-command.php
@@ -612,6 +612,9 @@ EOT
 	 */
 	protected function logs( InputInterface $input, OutputInterface $output ) {
 		if ( ! isset( $input->getArgument( 'options' )[0] ) ) {
+			if ( ! $this->require_tty( $output, 'composer server logs', 'composer server logs <service>  (e.g. php, db, nginx, elasticsearch)' ) ) {
+				return 1;
+			}
 			$helper = $this->getHelper( 'question' );
 			$question = new ChoiceQuestion(
 				'Please select a service (defaults to php)',
@@ -654,6 +657,10 @@ EOT
 	 * @return int
 	 */
 	protected function shell( InputInterface $input, OutputInterface $output ) {
+		if ( ! $this->require_tty( $output, 'composer server shell', 'composer server exec -- <command>' ) ) {
+			return 1;
+		}
+
 		$columns = exec( 'tput cols' );
 		$lines = exec( 'tput lines' );
 		$command_prefix = $this->get_base_command_prefix();
@@ -693,13 +700,20 @@ EOT
 		$columns = exec( 'tput cols' );
 		$lines = exec( 'tput lines' );
 
-		$base_command = sprintf(
-			// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
-			'docker exec -it -u root -e COLUMNS=%d -e LINES=%d -e MYSQL_PWD=wordpress %s-db',
-			$columns,
-			$lines,
-			$this->get_project_subdomain()
-		);
+		// Build the docker exec base command. Pass `-it` only for the
+		// interactive REPL; non-interactive paths (`db exec`) use `-i` so they
+		// work in scripts, CI, cron, and other no-TTY contexts.
+		$build_base_command = function ( bool $interactive ) use ( $columns, $lines ) : string {
+			$flags = $interactive ? '-it' : '-i';
+			return sprintf(
+				// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
+				'docker exec %s -u root -e COLUMNS=%d -e LINES=%d -e MYSQL_PWD=wordpress %s-db',
+				$flags,
+				$columns,
+				$lines,
+				$this->get_project_subdomain()
+			);
+		};
 
 		$return_val = 0;
 
@@ -785,11 +799,17 @@ EOT;
 				if ( substr( $query, -1 ) !== ';' ) {
 					$query = "$query;";
 				}
+				$base_command = $build_base_command( false );
 				// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
 				passthru( "$base_command mysql --database=wordpress --user=root $args -e \"$query\"", $return_val );
 				break;
 
 			case null:
+				if ( ! $this->require_tty( $output, 'composer server db', 'composer server db exec -- "<query>"' ) ) {
+					return 1;
+				}
+
+				$base_command = $build_base_command( true );
 				// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
 				passthru( "$base_command mysql --database=wordpress --user=root", $return_val );
 				break;
@@ -1282,6 +1302,41 @@ EOT;
 	 */
 	public static function is_linux() : bool {
 		return in_array( php_uname( 's' ), [ 'BSD', 'Linux', 'Solaris', 'Unknown' ], true );
+	}
+
+	/**
+	 * Check whether the current process is attached to an interactive terminal.
+	 *
+	 * @return boolean
+	 */
+	public static function is_tty() : bool {
+		return function_exists( 'posix_isatty' )
+			&& posix_isatty( STDIN )
+			&& posix_isatty( STDOUT );
+	}
+
+	/**
+	 * Gate a command on the presence of an interactive terminal.
+	 *
+	 * Prints a friendly error and returns false when no TTY is attached, so
+	 * scripted/CI/agent callers get a clear message instead of an opaque
+	 * failure from Docker (or a hung prompt).
+	 *
+	 * @param OutputInterface $output      Command output object.
+	 * @param string          $command     Full command label, e.g. 'composer server shell'.
+	 * @param string|null     $alternative Optional non-interactive alternative to suggest.
+	 * @return boolean True when a TTY is available; false otherwise.
+	 */
+	protected function require_tty( OutputInterface $output, string $command, ?string $alternative = null ) : bool {
+		if ( self::is_tty() ) {
+			return true;
+		}
+
+		$output->writeln( "<error>`$command` requires an interactive terminal.</>" );
+		if ( $alternative ) {
+			$output->writeln( "<info>For non-interactive use, try: $alternative</>" );
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Manual backport of #916 to `v25-branch`. The auto-backport bot couldn't apply this because v25-branch has a `case null:` arm in `db()` (vs master's restructured `default:`) and doesn't have the `s3` helper subcommands yet.

## Why backport
On GitHub Actions there is no controlling TTY, so the hardcoded `docker exec -it … -db` in `composer server db exec` errors with `the input device is not a TTY` before the SQL runs. The product-dev nightly CI uses this path indirectly via `composer dev-tools codecept`'s test-DB bootstrap (`DROP DATABASE … CREATE DATABASE test;…`), so the `test`/`test2` DBs never get created and codecept then fails with `[1044] Access denied for user 'wordpress'@'%' to database 'test'` for every module suite. Travis didn't hit this because its runner supplied enough of a pseudo-TTY for `-it` to work.

## What changed
Same shape as #916 against master, adapted for v25:
- `composer server db exec` drops `-t` and only passes `-i` so it runs without a controlling terminal.
- `composer server db` (interactive REPL on this branch is `case null:`), `shell`, and the `logs` service picker keep `-it` and gate on a new `require_tty()` that prints a clear error and a non-interactive alternative when no terminal is attached, instead of hanging or crashing on Docker's opaque error.
- Adds `is_tty()` / `require_tty()` helpers.
- The `s3` helper subcommands (`s3 import-uploads`, `s3 ls`, `s3 exec`) didn't exist on this branch yet, so the s3 portion of #916 isn't backported.

The `db` case on this branch differs from master:
- master collapsed `case null` (REPL) and `default` (unknown subcommand) into a single `default` arm with the non-interactive `-e`/`--execute`/`-B`/`--batch` detection inside.
- v25 still has separate `case null` and `default` arms, and the REPL path doesn't take extra options, so the `-e`/`-B` detection isn't needed here — the REPL is always interactive on this branch. Kept that simpler shape; just guarded `case null` with `require_tty()`.

## Test plan
- [ ] Trigger product-dev nightly against v25 after merge and confirm Altis 25 jobs no longer hit "Access denied for user 'wordpress'@'%' to database 'test'".
- [ ] Manual: `composer server db exec -- "SELECT 1; "` works without a TTY.
- [ ] Manual: `composer server db` with a TTY still opens the interactive REPL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)