### PR TITLE
Update PHP images and add PHP 8.5 support

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -107,9 +107,10 @@ class Docker_Compose_Generator {
 	 */
 	protected function get_php_reusable() : array {
 		$version_map = [
-			'8.4' => 'humanmade/altis-local-server-php:8.4.4',
-			'8.3' => 'humanmade/altis-local-server-php:8.3.23',
-			'8.2' => 'humanmade/altis-local-server-php:8.2.36',
+			'8.5' => 'humanmade/altis-local-server-php:8.5.3',
+			'8.4' => 'humanmade/altis-local-server-php:8.4.9',
+			'8.3' => 'humanmade/altis-local-server-php:8.3.24',
+			'8.2' => 'humanmade/altis-local-server-php:8.2.37',
 			'8.1' => 'humanmade/altis-local-server-php:6.0.30',
 		];
 


### PR DESCRIPTION
## Summary

Refresh the PHP image map in `class-docker-compose-generator.php` to pick up the latest patch releases from `humanmade/docker-wordpress-php`, and add PHP 8.5:

- **8.5** → `humanmade/altis-local-server-php:8.5.3` (new)
- **8.4** → `8.4.4` → `8.4.9`
- **8.3** → `8.3.23` → `8.3.24`
- **8.2** → `8.2.36` → `8.2.37`
- **8.1** unchanged (`6.0.30`)

## Test plan

- [ ] `composer server start` succeeds on each of `php: "8.5"`, `"8.4"`, `"8.3"`, `"8.2"`
- [ ] `composer server cli -- wp eval 'echo PHP_VERSION;'` reports the expected major.minor for each