### PR TITLE
Update PHP images to latest patch releases

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -107,8 +107,8 @@ class Docker_Compose_Generator {
 	 */
 	protected function get_php_reusable() : array {
 		$version_map = [
-			'8.3' => 'humanmade/altis-local-server-php:8.3.23',
-			'8.2' => 'humanmade/altis-local-server-php:8.2.36',
+			'8.3' => 'humanmade/altis-local-server-php:8.3.24',
+			'8.2' => 'humanmade/altis-local-server-php:8.2.37',
 			'8.1' => 'humanmade/altis-local-server-php:6.0.30',
 		];
 


### PR DESCRIPTION
## Summary

Refresh the PHP image map in `class-docker-compose-generator.php` to pick up the latest patch releases from `humanmade/docker-wordpress-php`:

- **8.3** → `8.3.23` → `8.3.24`
- **8.2** → `8.2.36` → `8.2.37`
- **8.1** unchanged (`6.0.30`)

No new PHP versions are added on this branch.

After merge, this will be auto-backported to `v23-branch` via the `backport v23-branch` label (the version map is identical there).

## Test plan

- [ ] `composer server start` succeeds on `php: "8.3"`, `"8.2"`