### PR TITLE
Use wildcard Host matchers instead of HostRegexp

### DIFF
--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -301,7 +301,7 @@ class Docker_Compose_Generator {
 				'labels' => [
 					'traefik.enable=true',
 					'traefik.docker.network=proxy',
-					"traefik.http.routers.{$this->project_name}-nodejs.rule=HostRegexp(`nodejs-{$this->hostname}`)",
+					"traefik.http.routers.{$this->project_name}-nodejs.rule=Host(`nodejs-{$this->hostname}`)",
 					"traefik.http.routers.{$this->project_name}-nodejs.priority=1",
 					"traefik.http.routers.{$this->project_name}-nodejs.entrypoints=web,websecure",
 					"traefik.http.routers.{$this->project_name}-nodejs.service={$this->project_name}-nodejs",
@@ -900,13 +900,13 @@ class Docker_Compose_Generator {
 	protected function get_primary_host_rule( array $extra_domains = [] ) : string {
 		$host_rules = [
 			"Host(`{$this->hostname}`)",
-			'HostRegexp(`^[A-Za-z0-9-]+\\.' . str_replace( '.', '\\.', $this->hostname ) . '$`)',
+			"Host(`*.{$this->hostname}`)",
 		];
 
 		$extra_domains = array_filter( array_map( 'trim', $extra_domains ) );
 		foreach ( $extra_domains as $domain ) {
 			$host_rules[] = "Host(`{$domain}`)";
-			$host_rules[] = 'HostRegexp(`^[A-Za-z0-9-]+\\.' . str_replace( '.', '\\.', $domain ) . '$`)';
+			$host_rules[] = "Host(`*.{$domain}`)";
 		}
 
 		return '(' . implode( ' || ', array_unique( $host_rules ) ) . ')';
@@ -920,7 +920,7 @@ class Docker_Compose_Generator {
 	protected function get_s3_client_host_rule() : string {
 		$client_hosts = [
 			"Host(`{$this->hostname}`)",
-			'HostRegexp(`^[A-Za-z0-9-]+\\.' . str_replace( '.', '\\.', $this->hostname ) . '$`)',
+			"Host(`*.{$this->hostname}`)",
 			"Host(`s3-{$this->hostname}`)",
 			'Host(`localhost`)',
 			"Host(`s3-{$this->project_name}.localhost`)",


### PR DESCRIPTION
## Summary

Replaces `HostRegexp` route rules in `Docker_Compose_Generator` with Traefik 3.7's single-level wildcard `Host` matcher:

- `get_primary_host_rule()` — `HostRegexp(\`^[A-Za-z0-9-]+\.<host>$\`)` → `Host(\`*.<host>\`)`, for the primary domain and every extra domain.
- `get_s3_client_host_rule()` — same swap for the S3 client subdomain rule.
- nodejs router rule — `HostRegexp(\`nodejs-<host>\`)` (no regex metacharacters) → `Host(\`nodejs-<host>\`)`.

Why:

- Simpler, cheaper matcher (no regex compile).
- TLSOptions can be associated with wildcard `Host` matchers, but **not** with `HostRegexp` (per the 3.7 migration notes). This unblocks per-domain TLS options in the future.

Behavior note: the wildcard accepts any DNS-valid label, while the old regex required `[A-Za-z0-9-]+`. For local dev hostnames this is a deliberate relaxation, not a regression.

## Dependencies

Requires Traefik ≥ 3.7. **Merge #932 first** (or merge them together).

## Test plan

- [ ] Primary host (`<project>.altis.dev`) still resolves.
- [ ] Subdomain multisite child (`sub.<project>.altis.dev`) still resolves.
- [ ] `extra_domains` configured in `local-server` config still resolve at both bare and subdomain levels.
- [ ] `/uploads/...` (S3 client routing) still works via Tachyon and direct.
- [ ] nodejs service (`nodejs-<project>.altis.dev`) routes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)