### PR TITLE
Bump symfony/yaml to ~6.4.40 for security advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require": {
 		"php": ">=8.2",
 		"composer-plugin-api": "^1.1 || ^2.0",
-		"symfony/yaml": "~6.3.12",
+		"symfony/yaml": "~6.4.40",
 		"symfony/console": "^5.4.24"
 	},
 	"extra": {


### PR DESCRIPTION
## Summary

Bumps the `symfony/yaml` constraint from `~6.3.12` to `~6.4.40` so Composer can resolve to a patched release of the 6.4 LTS line.

The current `~6.3.12` constraint resolves only to v6.3.12, which is now blocked by three security advisories reported 2026-05-20:

- `PKSA-b14r-zh1d-vdrc` / [CVE-2026-45133](https://symfony.com/cve-2026-45133) — YAML Parser Stack Exhaustion via Unbounded Recursion
- `PKSA-v5yj-8nmz-sk2q` / [CVE-2026-45304](https://symfony.com/cve-2026-45304) — Exponential Memory Allocation via Recursive Collection-Alias Expansion ("Billion Laughs")
- `PKSA-ft77-7h5f-p3r6` / [CVE-2026-45305](https://symfony.com/cve-2026-45305) — ReDoS via Catastrophic Backtracking in `Parser::cleanup()`

All three affect every 5.x/6.x/7.x/8.x release below the corresponding patched line (6.x patched at v6.4.40). Because the entire 6.3 line is EOL'd with no further patches planned, the constraint must cross into 6.4 to load a fixed version.

## Why this is safe (and safe to backport to v23–v26)

- **Only one call site:** `inc/composer/class-docker-compose-generator.php` uses `Yaml::dump( $array, 10, 2 )` — a signature stable since symfony/yaml 2.x. No 6.3 → 6.4 deprecations affect this usage.
- **PHP requirement already compatible:** `composer.json` requires `php: ">=8.2"` on master, v26, v25, v24, and v23 — symfony/yaml 6.4 requires PHP 8.1+, so all branches are compatible.
- **Identical composer.json across branches:** `git diff` shows zero changes in `composer.json` between master, v26-branch, v25-branch, v24-branch, and v23-branch, so the same one-line patch applies cleanly to all of them.
- **No transitive conflicts:** `codeception/codeception` (pulled in via `altis/dev-tools`) requires `symfony/yaml >=5.4.24 <9.0`, which the new constraint satisfies.

The backport bot will pick up the `backport v23-branch`, `backport v24-branch`, `backport v25-branch`, and `backport v26-branch` labels on merge. This is a minor-version bump rather than the patch-only updates Dependabot is configured for on those branches, but security advisories override that policy — there is no patched 6.3.x release.

## Test plan

- [x] `composer update altis/local-server symfony/yaml --dry-run` resolves without advisory errors in a downstream Altis project
- [x] `composer audit` reports no remaining symfony/yaml advisories after update
- [x] Local server still boots and `docker-compose.yml` is generated correctly (`Yaml::dump` output unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)