### PR TITLE
Add GitHub Actions CI workflow on v26-branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - 'v*-branch'
+  pull_request:
+    branches:
+      - master
+      - main
+      - 'v*-branch'
+
+jobs:
+  ci:
+    uses: humanmade/altis-dev-tools/.github/workflows/module-ci.yml@088bce7321fde60b9c22e792e764fa13ccd8f6ab
+    with:
+      altis-package: altis/local-server
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Adds the lightweight caller for `humanmade/altis-dev-tools/.github/workflows/module-ci.yml@088bce7` on `v26-branch`. Mirrors the equivalent file already on `master`. Backport labels included to fan this out to v23/v24/v25 once merged.