### PR TITLE
Update default PHP version to 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   ci:
-    uses: humanmade/altis-dev-tools/.github/workflows/module-ci.yml@088bce7321fde60b9c22e792e764fa13ccd8f6ab
+    uses: humanmade/altis-dev-tools/.github/workflows/module-ci.yml@4050cfac8dccff8b328b64726dccb90fec707d4
     with:
       altis-package: altis/local-server
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   ci:
-    uses: humanmade/altis-dev-tools/.github/workflows/module-ci.yml@4050cfac8dccff8b328b64726dccb90fec707d4
+    uses: humanmade/altis-dev-tools/.github/workflows/module-ci.yml@64050cfac8dccff8b328b64726dccb90fec707d4
     with:
       altis-package: altis/local-server
     secrets:

--- a/docs/php-version.md
+++ b/docs/php-version.md
@@ -11,7 +11,7 @@ To change the PHP version use the Local Server module configuration to set the `
         "altis": {
             "modules": {
                 "local-server": {
-                    "php": "8.3"
+                    "php": "8.4"
                 }
             }
         }

--- a/inc/composer/class-docker-compose-generator.php
+++ b/inc/composer/class-docker-compose-generator.php
@@ -884,7 +884,7 @@ class Docker_Compose_Generator {
 			'afterburner' => false,
 			'xray' => $modules['cloud']['xray'] ?? true,
 			'ignore-paths' => [],
-			'php' => '8.3',
+			'php' => '8.4',
 			'mysql' => '8.0',
 			'nodejs' => $modules['nodejs'] ?? false,
 		];


### PR DESCRIPTION
Promotes PHP 8.4 to the default local-server runtime; minimum stays 8.2.