### PR TITLE
Update Traefik to 3.7.7

### DIFF
--- a/docker/proxy.yml
+++ b/docker/proxy.yml
@@ -2,7 +2,7 @@ services:
   proxy:
     networks:
       - proxy
-    image: traefik:3.7.1
+    image: traefik:3.7.7
     container_name: altis-proxy
     mem_limit: 128m
     volumes:


### PR DESCRIPTION
Updates the Traefik image to 3.7.7

No migration needed.
Tested locally. No issues.