### PR TITLE
Update Traefik to 3.6.23

### DIFF
--- a/docker/proxy.yml
+++ b/docker/proxy.yml
@@ -2,7 +2,7 @@ services:
   proxy:
     networks:
       - proxy
-    image: traefik:3.6.12
+    image: traefik:3.6.23
     container_name: altis-proxy
     mem_limit: 128m
     volumes:


### PR DESCRIPTION
Updates the Traefik image to 3.6.23

No migration needed.
Tested locally. No issues.